### PR TITLE
feat(auth): Supabase Auth + Next.js 認証基盤を実装 (#4)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ build
 *.min.js
 pnpm-lock.yaml
 .claude
+ARCH_REVIEW_issue4.md

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,0 +1,9 @@
+import { LoginForm } from '@/components/auth/login-form'
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <LoginForm />
+    </main>
+  )
+}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1,9 +1,5 @@
-import { LoginForm } from '@/components/auth/login-form'
+import { redirect } from 'next/navigation'
 
 export default function SignupPage() {
-  return (
-    <main className="flex min-h-screen items-center justify-center p-4">
-      <LoginForm />
-    </main>
-  )
+  redirect('/login')
 }

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1,0 +1,9 @@
+import { LoginForm } from '@/components/auth/login-form'
+
+export default function SignupPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <LoginForm />
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/bookshelf/page.tsx
+++ b/apps/web/app/(protected)/bookshelf/page.tsx
@@ -9,7 +9,9 @@ export default async function BookshelfPage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
       <h1 className="text-4xl font-bold">本棚</h1>
-      <p className="mt-4 text-lg text-gray-600">ようこそ、{user?.email ?? 'ゲスト'} さん</p>
+      <p className="mt-4 text-lg text-gray-600">
+        ようこそ、{user?.user_metadata?.full_name ?? user?.user_metadata?.name ?? 'ゲスト'} さん
+      </p>
     </main>
   )
 }

--- a/apps/web/app/(protected)/bookshelf/page.tsx
+++ b/apps/web/app/(protected)/bookshelf/page.tsx
@@ -1,0 +1,15 @@
+import { createClient } from '@/lib/supabase/server'
+
+export default async function BookshelfPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="text-4xl font-bold">本棚</h1>
+      <p className="mt-4 text-lg text-gray-600">ようこそ、{user?.email ?? 'ゲスト'} さん</p>
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/layout.tsx
+++ b/apps/web/app/(protected)/layout.tsx
@@ -1,0 +1,19 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+
+export default async function ProtectedLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  return <>{children}</>
+}

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -4,15 +4,13 @@ import { createClient } from '@/lib/supabase/server'
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/bookshelf'
 
   if (code) {
     const supabase = await createClient()
+    // PKCE code exchange — @supabase/ssr が自動的に cookie にセッションを保存する
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      // open redirect 防止: / で始まる相対パスのみ許可
-      const safePath = next.startsWith('/') && !next.startsWith('//') ? next : '/bookshelf'
-      return NextResponse.redirect(`${origin}${safePath}`)
+      return NextResponse.redirect(`${origin}/bookshelf`)
     }
   }
 

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/bookshelf'
+
+  if (code) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      // open redirect 防止: / で始まる相対パスのみ許可
+      const safePath = next.startsWith('/') && !next.startsWith('//') ? next : '/bookshelf'
+      return NextResponse.redirect(`${origin}${safePath}`)
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login?error=auth_failed`)
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,14 @@
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
       <h1 className="text-4xl font-bold">BookHub</h1>
       <p className="mt-4 text-lg text-gray-600">漫画ヘビーユーザー向け本棚管理サービス</p>
+      <Button asChild className="mt-8">
+        <Link href="/login">ログイン / 新規登録</Link>
+      </Button>
     </main>
   )
 }

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { createClient } from '@/lib/supabase/client'
+
+export function LoginForm() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleGoogleLogin() {
+    setIsLoading(true)
+    setError(null)
+
+    const supabase = createClient()
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    })
+
+    if (error) {
+      setError('ログインに失敗しました。もう一度お試しください。')
+      setIsLoading(false)
+    }
+    // 成功時は Google にリダイレクトされるため setIsLoading(false) は不要
+  }
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>BookHub にログイン</CardTitle>
+        <CardDescription>Google アカウントでログインしてください</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+        <Button onClick={handleGoogleLogin} disabled={isLoading} className="w-full">
+          {isLoading ? 'リダイレクト中...' : 'Google でログイン'}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    )
+  },
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  ),
+)
+Card.displayName = 'Card'
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+)
+CardHeader.displayName = 'CardHeader'
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+)
+CardTitle.displayName = 'CardTitle'
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  ),
+)
+CardDescription.displayName = 'CardDescription'
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  ),
+)
+CardContent.displayName = 'CardContent'
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  ),
+)
+CardFooter.displayName = 'CardFooter'
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/apps/web/lib/supabase/client.ts
+++ b/apps/web/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  )
+}

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -37,18 +37,24 @@ export async function updateSession(request: NextRequest) {
   // 未認証 + 保護対象ルート
   if (!user && !isPublicPath) {
     if (isApiPath) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      const response = NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      supabaseResponse.cookies.getAll().forEach((cookie) => response.cookies.set(cookie))
+      return response
     }
     const url = request.nextUrl.clone()
     url.pathname = '/login'
-    return NextResponse.redirect(url)
+    const response = NextResponse.redirect(url)
+    supabaseResponse.cookies.getAll().forEach((cookie) => response.cookies.set(cookie))
+    return response
   }
 
   // 認証済みユーザーが /login or /signup にアクセスした場合は bookshelf へ
   if (user && (pathname === '/login' || pathname === '/signup')) {
     const url = request.nextUrl.clone()
     url.pathname = '/bookshelf'
-    return NextResponse.redirect(url)
+    const response = NextResponse.redirect(url)
+    supabaseResponse.cookies.getAll().forEach((cookie) => response.cookies.set(cookie))
+    return response
   }
 
   return supabaseResponse

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -1,0 +1,55 @@
+import { createServerClient } from '@supabase/ssr'
+import { NextResponse, type NextRequest } from 'next/server'
+
+const PUBLIC_PATHS = ['/', '/login', '/signup']
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          supabaseResponse = NextResponse.next({ request })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          )
+        },
+      },
+    },
+  )
+
+  // CRITICAL: getSession() はサーバーサイドで信頼不可。必ず getUser() を使うこと
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { pathname } = request.nextUrl
+  const isPublicPath = PUBLIC_PATHS.includes(pathname) || pathname.startsWith('/auth/')
+  const isApiPath = pathname.startsWith('/api/')
+
+  // 未認証 + 保護対象ルート
+  if (!user && !isPublicPath) {
+    if (isApiPath) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const url = request.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
+
+  // 認証済みユーザーが /login or /signup にアクセスした場合は bookshelf へ
+  if (user && (pathname === '/login' || pathname === '/signup')) {
+    const url = request.nextUrl.clone()
+    url.pathname = '/bookshelf'
+    return NextResponse.redirect(url)
+  }
+
+  return supabaseResponse
+}

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -1,0 +1,27 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function createClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            )
+          } catch {
+            // Server Component からの読み取り専用呼び出し時は set が失敗するが無視
+          }
+        },
+      },
+    },
+  )
+}

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -6,5 +6,7 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff|woff2|ttf|otf)$).*)',
+  ],
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,8 +1,8 @@
-import { type NextRequest, NextResponse } from 'next/server'
+import { type NextRequest } from 'next/server'
+import { updateSession } from '@/lib/supabase/middleware'
 
-export async function middleware(_request: NextRequest) {
-  // TODO: Supabase Auth セッション更新・ルート保護を実装 (#4)
-  return NextResponse.next()
+export async function middleware(request: NextRequest) {
+  return await updateSession(request)
 }
 
 export const config = {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,9 +16,12 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "next": "^15.3.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@bookhub/shared": "workspace:*",
+    "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.4",
     "next": "^15.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@bookhub/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@supabase/ssr':
         specifier: ^0.6.1
         version: 0.6.1(@supabase/supabase-js@2.103.0)
@@ -1349,6 +1352,24 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -5535,6 +5556,19 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@rollup/pluginutils@4.2.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,12 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.49.4
         version: 2.103.0
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: ^15.3.1
         version: 15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -69,6 +75,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.5(react@19.2.5)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.5
@@ -2271,6 +2280,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2280,6 +2292,10 @@ packages:
 
   cloudflare@4.5.0:
     resolution: {integrity: sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3802,6 +3818,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -6577,6 +6596,10 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   client-only@0.0.1: {}
 
   cliui@9.0.1:
@@ -6596,6 +6619,8 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -8437,6 +8462,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 


### PR DESCRIPTION
## 概要

Issue #4 の実装。Supabase Auth を Next.js App Router と統合し、Google OAuth による認証基盤を構築した。

## 変更内容

### Supabase クライアント3分割 (`lib/supabase/`)
- `client.ts` — ブラウザ用 `createBrowserClient` ラッパー
- `server.ts` — Server Component / Route Handler 用 `createServerClient` + `cookies()` ラッパー
- `middleware.ts` — `updateSession()` によるセッション更新・ルート保護

### ルート保護 (`middleware.ts`)
- 公開パスホワイトリスト方式（`/`, `/login`, `/signup`, `/auth/**` 以外は認証必須）
- ページルート: 未認証 → `/login` にリダイレクト
- API ルート: 未認証 → 401 JSON レスポンス（Chrome Extension 対応）
- `getUser()` でセッション検証（`getSession()` は不使用）

### 認証 UI
- `app/(auth)/login/page.tsx` — Google OAuth ログインページ
- `app/(auth)/signup/page.tsx` — `/login` にリダイレクト
- `components/auth/login-form.tsx` — Google OAuth ボタン（ローディング・エラー表示）

### OAuth フロー
- `app/auth/callback/route.ts` — PKCE code exchange。`/bookshelf` 固定リダイレクト（open redirect 防止）

### Protected ルート基盤
- `app/(protected)/layout.tsx` — サーバーサイド `getUser()` による二重チェック
- `app/(protected)/bookshelf/page.tsx` — プレースホルダー（Google 表示名を表示）

## セキュリティ対応
- `getSession()` を使用せず `getUser()` で Auth サーバーに問い合わせ
- open redirect 防止（`next` パラメータ廃止、固定リダイレクト）
- リダイレクト・401 レスポンスに更新済み cookie をコピー
- defense-in-depth: middleware + protected layout の二重チェック

## 動作確認チェックリスト

> ⚠️ 事前に Supabase Dashboard での Google OAuth プロバイダー設定と Redirect URL 登録が必要です。

- [ ] `/bookshelf` にアクセス → `/login` にリダイレクトされる
- [ ] Google OAuth ログイン → `/bookshelf` に到達できる
- [ ] 認証済みで `/login` にアクセス → `/bookshelf` にリダイレクトされる
- [ ] `profiles` テーブルにレコードが自動作成される

## 関連 Issue

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Google を使用したログイン機能を追加しました
  * ログイン画面とユーザー専用の本棚ページを追加しました
  * ホームページにログイン/新規登録へのボタンを追加しました

* **改善**
  * 認証されたユーザーのみが特定のページにアクセスできるように保護ページを実装しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->