### PR TITLE
test: テストセットアップ・CI ワークフロー追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "20"
+  PNPM_VERSION: "10"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @bookhub/shared build
+      - run: pnpm lint
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm format:check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @bookhub/shared build
+      - run: pnpm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build

--- a/apps/web/app/auth/callback/__tests__/route.test.ts
+++ b/apps/web/app/auth/callback/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { GET } from '../route'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    redirect: vi.fn((url: string) => ({ _redirectUrl: url })),
+  },
+}))
+
+function createRequest(url: string) {
+  return new Request(url)
+}
+
+function setupMockExchange(error: { message: string } | null) {
+  const mockExchange = vi.fn().mockResolvedValue({ error })
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { exchangeCodeForSession: mockExchange },
+  } as unknown as Awaited<ReturnType<typeof createClient>>)
+  return { mockExchange }
+}
+
+describe('GET /auth/callback', () => {
+  describe('正常系', () => {
+    it('code パラメータがあり exchangeCodeForSession 成功 → /bookshelf へリダイレクト', async () => {
+      setupMockExchange(null)
+      const request = createRequest('https://example.com/auth/callback?code=valid-code')
+      await GET(request)
+      expect(NextResponse.redirect).toHaveBeenCalledWith('https://example.com/bookshelf')
+    })
+
+    it('exchangeCodeForSession に code が正しく渡される', async () => {
+      const { mockExchange } = setupMockExchange(null)
+      const request = createRequest('https://example.com/auth/callback?code=my-code-123')
+      await GET(request)
+      expect(mockExchange).toHaveBeenCalledWith('my-code-123')
+    })
+  })
+
+  describe('エラー系', () => {
+    it('exchangeCodeForSession がエラー → /login?error=auth_failed へリダイレクト', async () => {
+      setupMockExchange({ message: 'invalid code' })
+      const request = createRequest('https://example.com/auth/callback?code=bad-code')
+      await GET(request)
+      expect(NextResponse.redirect).toHaveBeenCalledWith(
+        'https://example.com/login?error=auth_failed',
+      )
+    })
+
+    it('code パラメータなし → /login?error=auth_failed へリダイレクト', async () => {
+      const request = createRequest('https://example.com/auth/callback')
+      await GET(request)
+      expect(NextResponse.redirect).toHaveBeenCalledWith(
+        'https://example.com/login?error=auth_failed',
+      )
+    })
+
+    it('code が空文字 → /login?error=auth_failed へリダイレクト', async () => {
+      const request = createRequest('https://example.com/auth/callback?code=')
+      await GET(request)
+      expect(NextResponse.redirect).toHaveBeenCalledWith(
+        'https://example.com/login?error=auth_failed',
+      )
+    })
+
+    it('code なしの場合 createClient は呼ばれない', async () => {
+      const request = createRequest('https://example.com/auth/callback')
+      await GET(request)
+      expect(createClient).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('open redirect 防止', () => {
+    it('リダイレクト先は常に同一 origin を使用する', async () => {
+      setupMockExchange(null)
+      const request = createRequest('https://myapp.com/auth/callback?code=valid')
+      await GET(request)
+      expect(NextResponse.redirect).toHaveBeenCalledWith('https://myapp.com/bookshelf')
+    })
+  })
+})

--- a/apps/web/lib/supabase/__tests__/middleware.test.ts
+++ b/apps/web/lib/supabase/__tests__/middleware.test.ts
@@ -1,0 +1,266 @@
+import { createServerClient } from '@supabase/ssr'
+import { type NextRequest } from 'next/server'
+import { updateSession } from '../middleware'
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(),
+}))
+
+vi.mock('next/server', () => {
+  function makeCookieStore() {
+    const cookies = new Map<string, { name: string; value: string; options?: unknown }>()
+    return {
+      set(
+        nameOrCookie: string | { name: string; value: string; options?: unknown },
+        value?: string,
+        options?: unknown,
+      ) {
+        if (typeof nameOrCookie === 'object') {
+          cookies.set(nameOrCookie.name, nameOrCookie)
+        } else {
+          cookies.set(nameOrCookie, { name: nameOrCookie, value: value!, options })
+        }
+      },
+      getAll() {
+        return Array.from(cookies.values())
+      },
+    }
+  }
+
+  const NextResponse = {
+    next: vi.fn((_opts?: unknown) => ({
+      cookies: makeCookieStore(),
+      _type: 'next',
+    })),
+    redirect: vi.fn((url: URL) => ({
+      cookies: makeCookieStore(),
+      _type: 'redirect',
+      _url: url.toString(),
+    })),
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      cookies: makeCookieStore(),
+      _type: 'json',
+      _body: body,
+      _status: init?.status,
+    })),
+  }
+
+  return { NextResponse }
+})
+
+// --- Helpers ---
+
+function createMockRequest(pathname: string) {
+  const url = new URL(`http://localhost:3000${pathname}`)
+  const cookieStore = new Map<string, string>()
+
+  return {
+    cookies: {
+      getAll: () => Array.from(cookieStore.entries()).map(([name, value]) => ({ name, value })),
+      set: (name: string, value: string) => cookieStore.set(name, value),
+    },
+    nextUrl: {
+      pathname,
+      clone: () => new URL(url),
+    },
+  } as unknown as NextRequest
+}
+
+function setupMockAuth(user: { id: string; email: string } | null) {
+  const mockGetUser = vi.fn().mockResolvedValue({ data: { user } })
+  vi.mocked(createServerClient).mockReturnValue({
+    auth: { getUser: mockGetUser },
+  } as unknown as ReturnType<typeof createServerClient>)
+  return { mockGetUser }
+}
+
+// --- Tests ---
+
+describe('updateSession', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key'
+  })
+
+  describe('未認証ユーザー', () => {
+    beforeEach(() => {
+      setupMockAuth(null)
+    })
+
+    describe('公開パスへのアクセス（pass-through）', () => {
+      it.each(['/', '/login', '/signup'])('%s はそのまま通過する', async (pathname) => {
+        const request = createMockRequest(pathname)
+        const response = await updateSession(request)
+        expect((response as unknown as { _type: string })._type).toBe('next')
+      })
+
+      it('/auth/callback はそのまま通過する', async () => {
+        const request = createMockRequest('/auth/callback')
+        const response = await updateSession(request)
+        expect((response as unknown as { _type: string })._type).toBe('next')
+      })
+
+      it('/auth/confirm はそのまま通過する', async () => {
+        const request = createMockRequest('/auth/confirm')
+        const response = await updateSession(request)
+        expect((response as unknown as { _type: string })._type).toBe('next')
+      })
+    })
+
+    describe('保護ルートへのアクセス（リダイレクト）', () => {
+      it('/bookshelf は /login へリダイレクトする', async () => {
+        const request = createMockRequest('/bookshelf')
+        const response = await updateSession(request)
+        const res = response as unknown as { _type: string; _url: string }
+        expect(res._type).toBe('redirect')
+        expect(res._url).toContain('/login')
+      })
+
+      it('/settings は /login へリダイレクトする', async () => {
+        const request = createMockRequest('/settings')
+        const response = await updateSession(request)
+        const res = response as unknown as { _type: string; _url: string }
+        expect(res._type).toBe('redirect')
+        expect(res._url).toContain('/login')
+      })
+    })
+
+    describe('API ルートへのアクセス（401）', () => {
+      it('/api/books は 401 JSON を返す', async () => {
+        const request = createMockRequest('/api/books')
+        const response = await updateSession(request)
+        const res = response as unknown as {
+          _type: string
+          _body: { error: string }
+          _status: number
+        }
+        expect(res._type).toBe('json')
+        expect(res._body).toEqual({ error: 'Unauthorized' })
+        expect(res._status).toBe(401)
+      })
+
+      it('/api/nested/route は 401 JSON を返す', async () => {
+        const request = createMockRequest('/api/nested/route')
+        const response = await updateSession(request)
+        const res = response as unknown as { _type: string; _status: number }
+        expect(res._type).toBe('json')
+        expect(res._status).toBe(401)
+      })
+    })
+  })
+
+  describe('認証済みユーザー', () => {
+    const mockUser = { id: 'user-123', email: 'test@example.com' }
+
+    beforeEach(() => {
+      setupMockAuth(mockUser)
+    })
+
+    describe('ログインページからのリダイレクト', () => {
+      it('/login は /bookshelf へリダイレクトする', async () => {
+        const request = createMockRequest('/login')
+        const response = await updateSession(request)
+        const res = response as unknown as { _type: string; _url: string }
+        expect(res._type).toBe('redirect')
+        expect(res._url).toContain('/bookshelf')
+      })
+
+      it('/signup は /bookshelf へリダイレクトする', async () => {
+        const request = createMockRequest('/signup')
+        const response = await updateSession(request)
+        const res = response as unknown as { _type: string; _url: string }
+        expect(res._type).toBe('redirect')
+        expect(res._url).toContain('/bookshelf')
+      })
+    })
+
+    describe('通常のページアクセス（pass-through）', () => {
+      it.each(['/', '/bookshelf', '/settings'])('%s はそのまま通過する', async (pathname) => {
+        const request = createMockRequest(pathname)
+        const response = await updateSession(request)
+        expect((response as unknown as { _type: string })._type).toBe('next')
+      })
+    })
+  })
+
+  describe('Cookie 伝播', () => {
+    it('リダイレクト時に Cookie が伝播される', async () => {
+      vi.mocked(createServerClient).mockImplementation((_url, _key, config) => {
+        const cookies = (
+          config as {
+            cookies: {
+              setAll: (c: Array<{ name: string; value: string; options?: unknown }>) => void
+            }
+          }
+        ).cookies
+        cookies.setAll([{ name: 'sb-token', value: 'refreshed', options: { path: '/' } }])
+        return {
+          auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+        } as unknown as ReturnType<typeof createServerClient>
+      })
+
+      const request = createMockRequest('/bookshelf')
+      const response = await updateSession(request)
+      const res = response as unknown as {
+        _type: string
+        cookies: { getAll: () => Array<{ name: string; value: string }> }
+      }
+      expect(res._type).toBe('redirect')
+
+      const responseCookies = res.cookies.getAll()
+      expect(responseCookies.some((c) => c.name === 'sb-token')).toBe(true)
+    })
+
+    it('401 レスポンス時に Cookie が伝播される', async () => {
+      vi.mocked(createServerClient).mockImplementation((_url, _key, config) => {
+        const cookies = (
+          config as {
+            cookies: {
+              setAll: (c: Array<{ name: string; value: string; options?: unknown }>) => void
+            }
+          }
+        ).cookies
+        cookies.setAll([{ name: 'sb-token', value: 'refreshed', options: { path: '/' } }])
+        return {
+          auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+        } as unknown as ReturnType<typeof createServerClient>
+      })
+
+      const request = createMockRequest('/api/books')
+      const response = await updateSession(request)
+      const res = response as unknown as {
+        _type: string
+        cookies: { getAll: () => Array<{ name: string; value: string }> }
+      }
+      expect(res._type).toBe('json')
+
+      const responseCookies = res.cookies.getAll()
+      expect(responseCookies.some((c) => c.name === 'sb-token')).toBe(true)
+    })
+  })
+
+  describe('セキュリティ', () => {
+    it('getUser() が呼ばれる（getSession ではなく）', async () => {
+      const { mockGetUser } = setupMockAuth(null)
+      const request = createMockRequest('/')
+      await updateSession(request)
+      expect(mockGetUser).toHaveBeenCalledOnce()
+    })
+
+    it('createServerClient に正しい環境変数が渡される', async () => {
+      setupMockAuth(null)
+      const request = createMockRequest('/')
+      await updateSession(request)
+      expect(createServerClient).toHaveBeenCalledWith(
+        'https://test.supabase.co',
+        'test-anon-key',
+        expect.objectContaining({
+          cookies: expect.objectContaining({
+            getAll: expect.any(Function),
+            setAll: expect.any(Function),
+          }),
+        }),
+      )
+    })
+  })
+})

--- a/apps/web/lib/supabase/__tests__/middleware.test.ts
+++ b/apps/web/lib/supabase/__tests__/middleware.test.ts
@@ -82,6 +82,11 @@ describe('updateSession', () => {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key'
   })
 
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  })
+
   describe('未認証ユーザー', () => {
     beforeEach(() => {
       setupMockAuth(null)

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -14,7 +14,7 @@ export async function updateSession(request: NextRequest) {
         getAll() {
           return request.cookies.getAll()
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet: { name: string; value: string; options: Record<string, unknown> }[]) {
           cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({ request })
           cookiesToSet.forEach(({ name, value, options }) =>

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -12,7 +12,7 @@ export async function createClient() {
         getAll() {
           return cookieStore.getAll()
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet: { name: string; value: string; options: Record<string, unknown> }[]) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,10 @@
     "lint": "eslint .",
     "pages:build": "opennextjs-cloudflare build",
     "preview": "opennextjs-cloudflare dev",
-    "deploy": "opennextjs-cloudflare deploy"
+    "deploy": "opennextjs-cloudflare deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@bookhub/shared": "workspace:*",
@@ -30,10 +33,12 @@
     "@types/node": "^22.15.3",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.3",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.58.1"
+    "typescript-eslint": "^8.58.1",
+    "vitest": "^4.1.4"
   }
 }

--- a/apps/web/vitest-env.d.ts
+++ b/apps/web/vitest-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    globals: true,
+    include: ['**/__tests__/**/*.test.ts'],
+    environment: 'node',
+    mockReset: true,
+  },
+})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ['**/__tests__/**/*.test.ts'],
+    include: ['app/**/__tests__/**/*.test.ts', 'lib/**/__tests__/**/*.test.ts'],
     environment: 'node',
     mockReset: true,
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\" --ignore-path .prettierignore",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,json,md}\" --ignore-path .prettierignore",
     "fix": "pnpm -r lint --fix && pnpm format",
+    "test": "pnpm -r test",
+    "test:coverage": "pnpm -r test:coverage",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,12 +13,17 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "typescript": "^5.8.3"
+    "@vitest/coverage-v8": "^4.1.4",
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/shared/src/schemas/__tests__/book-schema.test.ts
+++ b/packages/shared/src/schemas/__tests__/book-schema.test.ts
@@ -1,0 +1,226 @@
+import { storeSchema, scrapeBookSchema, scrapePayloadSchema } from '../book-schema'
+
+const validBook = {
+  title: 'ワンピース',
+  author: '尾田栄一郎',
+  store: 'kindle' as const,
+}
+
+const fullBook = {
+  ...validBook,
+  volumeNumber: 107,
+  thumbnailUrl: 'https://example.com/cover.jpg',
+  isbn: '9784088835099',
+}
+
+// --- storeSchema ---
+
+describe('storeSchema', () => {
+  it.each(['kindle', 'dmm', 'other'])('有効なストア "%s" を受け入れる', (store) => {
+    expect(storeSchema.safeParse(store).success).toBe(true)
+  })
+
+  it.each(['kobo', 'bookwalker', '', 123, null, undefined])('無効な値 %j を拒否する', (value) => {
+    expect(storeSchema.safeParse(value).success).toBe(false)
+  })
+})
+
+// --- scrapeBookSchema ---
+
+describe('scrapeBookSchema', () => {
+  describe('正常系', () => {
+    it('必須フィールドのみで有効', () => {
+      const result = scrapeBookSchema.safeParse(validBook)
+      expect(result.success).toBe(true)
+    })
+
+    it('全フィールド指定で有効', () => {
+      const result = scrapeBookSchema.safeParse(fullBook)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('title', () => {
+    it('1文字は有効（min 境界）', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, title: 'A' })
+      expect(result.success).toBe(true)
+    })
+
+    it('500文字は有効（max 境界）', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, title: 'A'.repeat(500) })
+      expect(result.success).toBe(true)
+    })
+
+    it('空文字を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, title: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('501文字を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, title: 'A'.repeat(501) })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('author', () => {
+    it('1文字は有効（min 境界）', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, author: 'A' })
+      expect(result.success).toBe(true)
+    })
+
+    it('200文字は有効（max 境界）', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, author: 'A'.repeat(200) })
+      expect(result.success).toBe(true)
+    })
+
+    it('空文字を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, author: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('201文字を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, author: 'A'.repeat(201) })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('volumeNumber', () => {
+    it('正の整数を受け入れる', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, volumeNumber: 1 })
+      expect(result.success).toBe(true)
+    })
+
+    it('9999 を受け入れる（max 境界）', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, volumeNumber: 9999 })
+      expect(result.success).toBe(true)
+    })
+
+    it('0 を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, volumeNumber: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    it('負数を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, volumeNumber: -1 })
+      expect(result.success).toBe(false)
+    })
+
+    it('小数を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, volumeNumber: 1.5 })
+      expect(result.success).toBe(false)
+    })
+
+    it('10000 を拒否する（max 超過）', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, volumeNumber: 10000 })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('thumbnailUrl', () => {
+    it('https URL を受け入れる', () => {
+      const result = scrapeBookSchema.safeParse({
+        ...validBook,
+        thumbnailUrl: 'https://example.com/img.jpg',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('http URL を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({
+        ...validBook,
+        thumbnailUrl: 'http://example.com/img.jpg',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('不正な URL を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({
+        ...validBook,
+        thumbnailUrl: 'not-a-url',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('isbn', () => {
+    it('10桁の ISBN を受け入れる', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, isbn: '1234567890' })
+      expect(result.success).toBe(true)
+    })
+
+    it('13桁の ISBN を受け入れる', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, isbn: '1234567890123' })
+      expect(result.success).toBe(true)
+    })
+
+    it('9桁を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, isbn: '123456789' })
+      expect(result.success).toBe(false)
+    })
+
+    it('11桁を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, isbn: '12345678901' })
+      expect(result.success).toBe(false)
+    })
+
+    it('文字を含む ISBN を拒否する', () => {
+      const result = scrapeBookSchema.safeParse({ ...validBook, isbn: '123456789X' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('必須フィールド', () => {
+    it('title 欠落を拒否する', () => {
+      const { title: _, ...noTitle } = validBook
+      expect(scrapeBookSchema.safeParse(noTitle).success).toBe(false)
+    })
+
+    it('author 欠落を拒否する', () => {
+      const { author: _, ...noAuthor } = validBook
+      expect(scrapeBookSchema.safeParse(noAuthor).success).toBe(false)
+    })
+
+    it('store 欠落を拒否する', () => {
+      const { store: _, ...noStore } = validBook
+      expect(scrapeBookSchema.safeParse(noStore).success).toBe(false)
+    })
+  })
+})
+
+// --- scrapePayloadSchema ---
+
+describe('scrapePayloadSchema', () => {
+  it('1件の配列を受け入れる（min 境界）', () => {
+    const result = scrapePayloadSchema.safeParse({ books: [validBook] })
+    expect(result.success).toBe(true)
+  })
+
+  it('500件の配列を受け入れる（max 境界）', () => {
+    const books = Array.from({ length: 500 }, () => validBook)
+    const result = scrapePayloadSchema.safeParse({ books })
+    expect(result.success).toBe(true)
+  })
+
+  it('空配列を拒否する', () => {
+    const result = scrapePayloadSchema.safeParse({ books: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('501件の配列を拒否する', () => {
+    const books = Array.from({ length: 501 }, () => validBook)
+    const result = scrapePayloadSchema.safeParse({ books })
+    expect(result.success).toBe(false)
+  })
+
+  it('不正な book が含まれる場合を拒否する', () => {
+    const result = scrapePayloadSchema.safeParse({
+      books: [validBook, { title: '', author: '', store: 'invalid' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('books フィールド欠落を拒否する', () => {
+    const result = scrapePayloadSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/shared/src/vitest-env.d.ts
+++ b/packages/shared/src/vitest-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -7,5 +7,5 @@
     "rootDir": "./src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__"]
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.2
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -112,6 +115,9 @@ importers:
       typescript-eslint:
         specifier: ^8.58.1
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3))
 
   packages/shared:
     dependencies:
@@ -119,9 +125,15 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3))
 
 packages:
 
@@ -452,6 +464,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -1744,6 +1760,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@supabase/auth-js@2.103.0':
     resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
     engines: {node: '>=20.0.0'}
@@ -1877,8 +1896,14 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chrome@0.0.324':
     resolution: {integrity: sha512-puFoA5uJbN9+oaD/MjtMY13H7vPvO/IlSP4pe+uD/c+hB7HsbcOOLVRZlRWgkDSqupw4R+53pS9K9ORHYyMBCg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2083,6 +2108,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+    peerDependencies:
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
   '@webcomponents/custom-elements@1.6.0':
     resolution: {integrity: sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==}
 
@@ -2177,8 +2240,15 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -2271,6 +2341,10 @@ packages:
 
   caniuse-lite@1.0.30001787:
     resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2499,6 +2573,9 @@ packages:
   es-module-lexer@0.10.5:
     resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2683,6 +2760,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2698,6 +2778,10 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -2924,6 +3008,9 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -3095,6 +3182,18 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -3106,6 +3205,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3259,6 +3361,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3448,6 +3557,9 @@ packages:
 
   obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -3715,6 +3827,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3736,9 +3851,15 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3834,9 +3955,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3984,6 +4116,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
@@ -4018,6 +4191,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4923,6 +5101,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
@@ -6008,6 +6188,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@supabase/auth-js@2.103.0':
     dependencies:
       tslib: 2.8.1
@@ -6133,10 +6315,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chrome@0.0.324':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -6380,6 +6569,61 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3))
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@webcomponents/custom-elements@1.6.0': {}
 
   abort-controller@3.0.0:
@@ -6497,7 +6741,15 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -6588,6 +6840,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001787: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6868,6 +7122,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@0.10.5: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -7239,6 +7495,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -7256,6 +7516,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  expect-type@1.3.0: {}
 
   express@5.2.1:
     dependencies:
@@ -7522,6 +7784,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-escaper@2.0.2: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -7687,6 +7951,19 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -7701,6 +7978,8 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   jiti@2.6.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -7822,6 +8101,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
 
@@ -7994,6 +8283,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obliterator@1.6.1: {}
+
+  obug@2.1.1: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -8354,6 +8645,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -8369,7 +8662,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -8476,10 +8773,16 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8646,6 +8949,34 @@ snapshots:
       terser: 5.16.9
       yaml: 2.8.3
 
+  vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@4.0.0-beta.3: {}
 
   webidl-conversions@3.0.1: {}
@@ -8703,6 +9034,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

- Vitest + @vitest/coverage-v8 を `packages/shared` と `apps/web` に導入
- 既存の認証・バリデーションコードに対するテスト 67 件を追加
- GitHub Actions CI ワークフロー（lint, format, test, build 並列実行）を追加

### テスト追加対象
- `packages/shared/schemas/book-schema.ts` — Zod スキーマのバリデーションテスト（42 件）
- `apps/web/lib/supabase/middleware.ts` — ルート保護ロジック・Cookie 伝播テスト（18 件）
- `apps/web/app/auth/callback/route.ts` — OAuth コールバックの正常系・エラー系テスト（7 件）

### その他の変更
- `middleware.ts`, `server.ts` の `cookiesToSet` に型注釈追加（Next.js ビルドの strict type check 対応）
- `packages/shared/tsconfig.json` でテストファイルをビルド対象から除外

## Test plan

- [x] `pnpm test` — 67 テスト全 PASS
- [x] `pnpm lint` — エラーなし
- [x] `pnpm format:check` — 問題なし
- [x] `pnpm build` — 全パッケージビルド成功

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 認証、ミドルウェア、スキーマ検証の包括的なテストスイートを追加しました。
  * ワークスペース全体でテストを実行するためのスクリプトを追加しました。

* **Chores**
  * メインブランチへのプッシュとプルリクエストに対応するCI/CDパイプラインを設定しました。
  * リント、フォーマット、テスト、ビルドの自動検証を有効化しました。
  * Vitestテストフレームワークと関連する依存関係をセットアップしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->