### PR TITLE
feat(extension): Chrome 拡張機能の基盤を構築 #9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,26 @@ MVP対象外（フェーズ2以降）:
 
 ## Common Commands
 
+### ルート
+
 ```bash
 pnpm dev          # Web アプリ開発サーバー起動
 pnpm build        # 全パッケージビルド
 pnpm lint         # 全パッケージ lint
 pnpm fix          # lint 自動修正 + prettier フォーマット（コミット前推奨）
 pnpm format:check # フォーマットチェックのみ
+pnpm test         # 全パッケージテスト実行
+```
+
+### Chrome 拡張機能
+
+```bash
+pnpm --filter extension dev           # 拡張機能開発ビルド（HMR あり）
+pnpm --filter extension build         # 拡張機能開発用ビルド
+BOOKHUB_API_URL=https://... pnpm --filter extension build:prod # 本番ビルド（HTTPS 必須）
+pnpm --filter extension test          # テスト実行
+pnpm --filter extension test:watch    # テストウォッチ
+pnpm --filter extension test:coverage # テストカバレッジ
 ```
 
 pre-commit フック（husky）により、コミット時に `pnpm lint` と `pnpm format:check` が自動実行される。

--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -5,7 +5,10 @@ export default defineManifest({
   name: 'BookHub',
   version: '0.0.1',
   description: '漫画ヘビーユーザー向け本棚管理・二度買い防止サービス',
-  permissions: ['storage', 'activeTab', 'tabs'],
+  // activeTab は現状不使用だが、将来的に手動スクレイピングトリガーで必要になる可能性あり
+  permissions: ['storage', 'tabs'],
+  // TODO(#10, #11): 各ストアのスクレイピング対象 URL が確定したら、購入履歴ページのみに絞る
+  // 例: https://www.amazon.co.jp/hz/mycd/digital-console/contentlist/*
   host_permissions: ['https://www.amazon.co.jp/*', 'https://book.dmm.com/*'],
   action: {
     default_popup: 'src/popup/index.html',

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --mode development",
+    "build:prod": "vite build --mode production",
     "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@bookhub/shared": "workspace:*"
@@ -16,9 +19,11 @@
     "@types/chrome": "^0.0.324",
     "@typescript-eslint/eslint-plugin": "^8.58.1",
     "@typescript-eslint/parser": "^8.58.1",
+    "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^10.2.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.58.1",
-    "vite": "^6.3.3"
+    "vite": "^6.3.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/apps/extension/src/background/__tests__/index.test.ts
+++ b/apps/extension/src/background/__tests__/index.test.ts
@@ -38,7 +38,8 @@ vi.stubGlobal('chrome', {
   },
   tabs: {
     query: vi.fn((queryInfo: { url: string }) => {
-      if (queryInfo.url.includes('localhost')) {
+      // __API_BASE_URL__ は http://localhost:3000 なので bookshelf パターンにマッチ
+      if (queryInfo.url.includes('localhost:3000/bookshelf')) {
         return Promise.resolve([mockTabs[0]])
       }
       return Promise.resolve([])
@@ -291,9 +292,65 @@ describe('background', () => {
       })
     })
 
+    describe('全て重複の場合', () => {
+      it('savedCount=0, duplicateCount>0 のとき status が partial になる', async () => {
+        const apiResponse = {
+          savedCount: 0,
+          duplicateCount: 3,
+          duplicates: [
+            { title: '漫画A', existingStores: ['kindle'] },
+            { title: '漫画B', existingStores: ['dmm'] },
+            { title: '漫画C', existingStores: ['kindle', 'dmm'] },
+          ],
+        }
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(apiResponse),
+        })
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        await handleMessage(message, mockSender)
+
+        const syncResult = mockStorageData.get('bookhub_last_sync_result') as Record<
+          string,
+          unknown
+        >
+        expect(syncResult).toMatchObject({
+          status: 'partial',
+          savedCount: 0,
+          duplicateCount: 3,
+        })
+      })
+    })
+
     describe('unknown message', () => {
       it('不明なメッセージ type の場合 UNKNOWN_ERROR を返す', async () => {
         const result = await handleMessage({ type: 'INVALID_TYPE' }, mockSender)
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: false,
+            code: 'UNKNOWN_ERROR',
+          }),
+        )
+      })
+
+      it('null の場合 UNKNOWN_ERROR を返す', async () => {
+        const result = await handleMessage(null, mockSender)
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: false,
+            code: 'UNKNOWN_ERROR',
+          }),
+        )
+      })
+
+      it('type が文字列でない場合 UNKNOWN_ERROR を返す', async () => {
+        const result = await handleMessage({ type: 123 }, mockSender)
         expect(result).toEqual(
           expect.objectContaining({
             success: false,

--- a/apps/extension/src/background/__tests__/index.test.ts
+++ b/apps/extension/src/background/__tests__/index.test.ts
@@ -11,8 +11,11 @@ const mockTabs = [
   { id: 2, url: 'https://www.amazon.co.jp/kindle' },
 ]
 
+const EXTENSION_ID = 'test-extension-id'
+
 vi.stubGlobal('chrome', {
   runtime: {
+    id: EXTENSION_ID,
     onInstalled: { addListener: vi.fn() },
     onMessage: { addListener: vi.fn() },
     lastError: null,
@@ -70,7 +73,7 @@ describe('background', () => {
     },
   ]
 
-  const mockSender: chrome.runtime.MessageSender = { id: 'test-extension-id' }
+  const mockSender: chrome.runtime.MessageSender = { id: EXTENSION_ID }
 
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -324,6 +327,39 @@ describe('background', () => {
           status: 'partial',
           savedCount: 0,
           duplicateCount: 3,
+        })
+      })
+    })
+
+    describe('sender validation', () => {
+      it('sender.id が自拡張機能と異なる場合 UNKNOWN_ERROR を返す', async () => {
+        const foreignSender: chrome.runtime.MessageSender = { id: 'foreign-extension-id' }
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        const result = await handleMessage(message, foreignSender)
+        expect(result).toEqual({
+          success: false,
+          error: '不正な送信元です',
+          code: 'UNKNOWN_ERROR',
+        })
+        // fetch が呼ばれていないことを確認
+        expect(mockFetch).not.toHaveBeenCalled()
+      })
+
+      it('sender.id が undefined の場合 UNKNOWN_ERROR を返す', async () => {
+        const noIdSender: chrome.runtime.MessageSender = {}
+
+        const result = await handleMessage(
+          { type: 'SEND_SCRAPED_BOOKS', books: testBooks },
+          noIdSender,
+        )
+        expect(result).toEqual({
+          success: false,
+          error: '不正な送信元です',
+          code: 'UNKNOWN_ERROR',
         })
       })
     })

--- a/apps/extension/src/background/__tests__/index.test.ts
+++ b/apps/extension/src/background/__tests__/index.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { ScrapeBook } from '@bookhub/shared'
+import type { SendScrapedBooksMessage, ReloadBookshelfMessage } from '../../types/messages.js'
+
+// --- chrome API モック ---
+
+const mockStorageData = new Map<string, unknown>()
+
+const mockTabs = [
+  { id: 1, url: 'http://localhost:3000/bookshelf' },
+  { id: 2, url: 'https://www.amazon.co.jp/kindle' },
+]
+
+vi.stubGlobal('chrome', {
+  runtime: {
+    onInstalled: { addListener: vi.fn() },
+    onMessage: { addListener: vi.fn() },
+    lastError: null,
+  },
+  storage: {
+    session: {
+      get: vi.fn((keys: string[]) => {
+        const result: Record<string, unknown> = {}
+        for (const key of keys) {
+          const value = mockStorageData.get(key)
+          if (value !== undefined) result[key] = value
+        }
+        return Promise.resolve(result)
+      }),
+      set: vi.fn((items: Record<string, unknown>) => {
+        for (const [key, value] of Object.entries(items)) {
+          mockStorageData.set(key, value)
+        }
+        return Promise.resolve()
+      }),
+      remove: vi.fn(),
+    },
+  },
+  tabs: {
+    query: vi.fn((queryInfo: { url: string }) => {
+      if (queryInfo.url.includes('localhost')) {
+        return Promise.resolve([mockTabs[0]])
+      }
+      return Promise.resolve([])
+    }),
+    reload: vi.fn().mockResolvedValue(undefined),
+  },
+})
+
+// --- fetch モック ---
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// --- __API_BASE_URL__ モック ---
+
+vi.stubGlobal('__API_BASE_URL__', 'http://localhost:3000')
+
+describe('background', () => {
+  let handleMessage: (message: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>
+
+  const testBooks: ScrapeBook[] = [
+    {
+      title: 'テスト漫画 1巻',
+      author: 'テスト作者',
+      volumeNumber: 1,
+      store: 'kindle',
+      isAdult: false,
+    },
+  ]
+
+  const mockSender: chrome.runtime.MessageSender = { id: 'test-extension-id' }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockStorageData.clear()
+    mockStorageData.set('bookhub_access_token', 'test-token')
+
+    // background/index.ts を import するとリスナーが登録される
+    // onMessage.addListener に渡された関数を取り出す
+    const bg = await import('../index.js')
+    handleMessage = bg.handleMessage
+  })
+
+  describe('handleMessage', () => {
+    describe('SEND_SCRAPED_BOOKS', () => {
+      it('認証トークンがない場合 AUTH_ERROR を返す', async () => {
+        mockStorageData.delete('bookhub_access_token')
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        const result = await handleMessage(message, mockSender)
+        expect(result).toEqual({
+          success: false,
+          error: '未認証: ログインが必要です',
+          code: 'AUTH_ERROR',
+        })
+      })
+
+      it('バリデーションエラーの場合 VALIDATION_ERROR を返す', async () => {
+        const invalidMessage: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: [{ title: '', author: '', store: 'kindle', isAdult: false } as ScrapeBook],
+        }
+
+        const result = await handleMessage(invalidMessage, mockSender)
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: false,
+            code: 'VALIDATION_ERROR',
+          }),
+        )
+      })
+
+      it('API が 200 を返す場合、成功レスポンスを返す', async () => {
+        const apiResponse = {
+          savedCount: 1,
+          duplicateCount: 0,
+          duplicates: [],
+        }
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(apiResponse),
+        })
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        const result = await handleMessage(message, mockSender)
+
+        expect(result).toEqual({ success: true, data: apiResponse })
+        expect(mockFetch).toHaveBeenCalledWith(
+          'http://localhost:3000/api/scrape',
+          expect.objectContaining({
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+          }),
+        )
+      })
+
+      it('API が 401 を返す場合 AUTH_ERROR を返す', async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ error: 'Unauthorized' }),
+        })
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        const result = await handleMessage(message, mockSender)
+        expect(result).toEqual({
+          success: false,
+          error: '認証エラー: 再ログインが必要です',
+          code: 'AUTH_ERROR',
+        })
+      })
+
+      it('API が 400 を返す場合 VALIDATION_ERROR を返す', async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ error: 'Bad Request' }),
+        })
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        const result = await handleMessage(message, mockSender)
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: false,
+            code: 'VALIDATION_ERROR',
+          }),
+        )
+      })
+
+      it('API が 500 を返す場合 API_ERROR を返す', async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ error: 'Internal Server Error' }),
+        })
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        const result = await handleMessage(message, mockSender)
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: false,
+            code: 'API_ERROR',
+          }),
+        )
+      })
+
+      it('ネットワークエラーの場合 NETWORK_ERROR を返す', async () => {
+        mockFetch.mockRejectedValue(new TypeError('Failed to fetch'))
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        const result = await handleMessage(message, mockSender)
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: false,
+            code: 'NETWORK_ERROR',
+          }),
+        )
+      })
+
+      it('成功時に同期結果を storage に保存する', async () => {
+        const apiResponse = {
+          savedCount: 3,
+          duplicateCount: 1,
+          duplicates: [{ title: '既存漫画', existingStores: ['dmm'] }],
+        }
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(apiResponse),
+        })
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        await handleMessage(message, mockSender)
+
+        const syncResult = mockStorageData.get('bookhub_last_sync_result') as Record<
+          string,
+          unknown
+        >
+        expect(syncResult).toMatchObject({
+          status: 'partial',
+          savedCount: 3,
+          duplicateCount: 1,
+        })
+      })
+
+      it('成功時に本棚タブをリロードする', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              savedCount: 1,
+              duplicateCount: 0,
+              duplicates: [],
+            }),
+        })
+
+        const message: SendScrapedBooksMessage = {
+          type: 'SEND_SCRAPED_BOOKS',
+          books: testBooks,
+        }
+
+        await handleMessage(message, mockSender)
+
+        expect(chrome.tabs.query).toHaveBeenCalled()
+        expect(chrome.tabs.reload).toHaveBeenCalledWith(1)
+      })
+    })
+
+    describe('RELOAD_BOOKSHELF', () => {
+      it('本棚タブをリロードする', async () => {
+        const message: ReloadBookshelfMessage = { type: 'RELOAD_BOOKSHELF' }
+
+        await handleMessage(message, mockSender)
+
+        expect(chrome.tabs.query).toHaveBeenCalled()
+        expect(chrome.tabs.reload).toHaveBeenCalledWith(1)
+      })
+    })
+
+    describe('unknown message', () => {
+      it('不明なメッセージ type の場合 UNKNOWN_ERROR を返す', async () => {
+        const result = await handleMessage({ type: 'INVALID_TYPE' }, mockSender)
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: false,
+            code: 'UNKNOWN_ERROR',
+          }),
+        )
+      })
+    })
+  })
+})

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -11,15 +11,26 @@ chrome.runtime.onInstalled.addListener(() => {
 
 // --- メッセージハンドラ（テスト用に export） ---
 
+function isValidMessage(message: unknown): message is ExtensionMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    typeof (message as { type: unknown }).type === 'string'
+  )
+}
+
 export async function handleMessage(
   message: unknown,
   _sender: chrome.runtime.MessageSender, // eslint-disable-line @typescript-eslint/no-unused-vars
 ): Promise<MessageResponse<ScrapeResponse>> {
-  const msg = message as ExtensionMessage
+  if (!isValidMessage(message)) {
+    return { success: false, error: '不正なメッセージ形式です', code: 'UNKNOWN_ERROR' }
+  }
 
-  switch (msg.type) {
+  switch (message.type) {
     case 'SEND_SCRAPED_BOOKS':
-      return await handleSendScrapedBooks(msg.books)
+      return await handleSendScrapedBooks(message.books)
     case 'RELOAD_BOOKSHELF':
       await reloadBookshelfTabs()
       return { success: true, data: { savedCount: 0, duplicateCount: 0, duplicates: [] } }
@@ -89,8 +100,17 @@ async function handleSendScrapedBooks(books: unknown[]): Promise<MessageResponse
   const data = (await response.json()) as ScrapeResponse
 
   // 5. 同期結果を保存
+  let status: SyncResult['status']
+  if (data.savedCount > 0 && data.duplicateCount === 0) {
+    status = 'success'
+  } else if (data.savedCount > 0 && data.duplicateCount > 0) {
+    status = 'partial'
+  } else {
+    // savedCount === 0: 全て重複 or 空データ
+    status = 'partial'
+  }
   const syncResult: SyncResult = {
-    status: data.duplicateCount > 0 && data.savedCount > 0 ? 'partial' : 'success',
+    status,
     savedCount: data.savedCount,
     duplicateCount: data.duplicateCount,
     duplicates: data.duplicates,
@@ -107,14 +127,11 @@ async function handleSendScrapedBooks(books: unknown[]): Promise<MessageResponse
 // --- 本棚タブリロード ---
 
 async function reloadBookshelfTabs(): Promise<void> {
-  const bookshelfPatterns = ['http://localhost:3000/bookshelf*', 'https://*.pages.dev/bookshelf*']
-
-  for (const pattern of bookshelfPatterns) {
-    const tabs = await chrome.tabs.query({ url: pattern })
-    for (const tab of tabs) {
-      if (tab.id !== undefined) {
-        await chrome.tabs.reload(tab.id)
-      }
+  const pattern = `${__API_BASE_URL__}/bookshelf*`
+  const tabs = await chrome.tabs.query({ url: pattern })
+  for (const tab of tabs) {
+    if (tab.id !== undefined) {
+      await chrome.tabs.reload(tab.id)
     }
   }
 }

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -1,2 +1,120 @@
-// Service Worker
-// TODO: 認証トークン管理・拡張機能の初期化処理を実装 (#9)
+import { scrapePayloadSchema } from '@bookhub/shared'
+import type { ScrapeResponse } from '@bookhub/shared'
+import type { ExtensionMessage, MessageResponse, SyncResult } from '../types/messages.js'
+import { getAccessToken, setLastSyncResult } from '../utils/storage.js'
+
+// --- Service Worker 初期化 ---
+
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('[BookHub] Extension installed')
+})
+
+// --- メッセージハンドラ（テスト用に export） ---
+
+export async function handleMessage(
+  message: unknown,
+  _sender: chrome.runtime.MessageSender, // eslint-disable-line @typescript-eslint/no-unused-vars
+): Promise<MessageResponse<ScrapeResponse>> {
+  const msg = message as ExtensionMessage
+
+  switch (msg.type) {
+    case 'SEND_SCRAPED_BOOKS':
+      return await handleSendScrapedBooks(msg.books)
+    case 'RELOAD_BOOKSHELF':
+      await reloadBookshelfTabs()
+      return { success: true, data: { savedCount: 0, duplicateCount: 0, duplicates: [] } }
+    default:
+      return { success: false, error: '不明なメッセージタイプです', code: 'UNKNOWN_ERROR' }
+  }
+}
+
+// --- リスナーをトップレベルで登録 ---
+
+chrome.runtime.onMessage.addListener(
+  (message: unknown, sender: chrome.runtime.MessageSender, sendResponse) => {
+    handleMessage(message, sender).then(sendResponse)
+    return true // 非同期レスポンスを有効化
+  },
+)
+
+// --- スクレイピングデータ送信 ---
+
+async function handleSendScrapedBooks(books: unknown[]): Promise<MessageResponse<ScrapeResponse>> {
+  // 1. 認証トークン取得
+  const token = await getAccessToken()
+  if (!token) {
+    return { success: false, error: '未認証: ログインが必要です', code: 'AUTH_ERROR' }
+  }
+
+  // 2. バリデーション
+  const parsed = scrapePayloadSchema.safeParse({ books })
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: `バリデーションエラー: ${parsed.error.issues[0]?.message ?? '不正なデータ'}`,
+      code: 'VALIDATION_ERROR',
+    }
+  }
+
+  // 3. API にPOST
+  let response: Response
+  try {
+    response = await fetch(`${__API_BASE_URL__}/api/scrape`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ books: parsed.data.books }),
+    })
+  } catch {
+    return { success: false, error: 'ネットワークエラーが発生しました', code: 'NETWORK_ERROR' }
+  }
+
+  // 4. レスポンスハンドリング
+  if (!response.ok) {
+    if (response.status === 401) {
+      return { success: false, error: '認証エラー: 再ログインが必要です', code: 'AUTH_ERROR' }
+    }
+    if (response.status === 400) {
+      return {
+        success: false,
+        error: 'サーバーバリデーションエラー',
+        code: 'VALIDATION_ERROR',
+      }
+    }
+    return { success: false, error: 'サーバーエラーが発生しました', code: 'API_ERROR' }
+  }
+
+  const data = (await response.json()) as ScrapeResponse
+
+  // 5. 同期結果を保存
+  const syncResult: SyncResult = {
+    status: data.duplicateCount > 0 && data.savedCount > 0 ? 'partial' : 'success',
+    savedCount: data.savedCount,
+    duplicateCount: data.duplicateCount,
+    duplicates: data.duplicates,
+    timestamp: Date.now(),
+  }
+  await setLastSyncResult(syncResult)
+
+  // 6. 本棚タブをリロード
+  await reloadBookshelfTabs()
+
+  return { success: true, data }
+}
+
+// --- 本棚タブリロード ---
+
+async function reloadBookshelfTabs(): Promise<void> {
+  const bookshelfPatterns = ['http://localhost:3000/bookshelf*', 'https://*.pages.dev/bookshelf*']
+
+  for (const pattern of bookshelfPatterns) {
+    const tabs = await chrome.tabs.query({ url: pattern })
+    for (const tab of tabs) {
+      if (tab.id !== undefined) {
+        await chrome.tabs.reload(tab.id)
+      }
+    }
+  }
+}

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -22,8 +22,13 @@ function isValidMessage(message: unknown): message is ExtensionMessage {
 
 export async function handleMessage(
   message: unknown,
-  _sender: chrome.runtime.MessageSender, // eslint-disable-line @typescript-eslint/no-unused-vars
+  sender: chrome.runtime.MessageSender,
 ): Promise<MessageResponse<ScrapeResponse>> {
+  // 自拡張機能からのメッセージのみ受け付ける
+  if (sender.id !== chrome.runtime.id) {
+    return { success: false, error: '不正な送信元です', code: 'UNKNOWN_ERROR' }
+  }
+
   if (!isValidMessage(message)) {
     return { success: false, error: '不正なメッセージ形式です', code: 'UNKNOWN_ERROR' }
   }

--- a/apps/extension/src/content/shared/__tests__/sender.test.ts
+++ b/apps/extension/src/content/shared/__tests__/sender.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { ScrapeBook } from '@bookhub/shared'
+import type { SendScrapedBooksResponse } from '../../../types/messages.js'
+
+const mockSendMessage = vi.fn()
+
+vi.stubGlobal('chrome', {
+  runtime: {
+    sendMessage: mockSendMessage,
+    lastError: null,
+  },
+})
+
+describe('sender', () => {
+  let sender: typeof import('../sender.js')
+
+  const testBooks: ScrapeBook[] = [
+    {
+      title: 'テスト漫画 1巻',
+      author: 'テスト作者',
+      volumeNumber: 1,
+      store: 'kindle',
+      isAdult: false,
+    },
+  ]
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // lastError をリセット
+    Object.defineProperty(chrome.runtime, 'lastError', {
+      value: null,
+      writable: true,
+      configurable: true,
+    })
+    sender = await import('../sender.js')
+  })
+
+  describe('sendScrapedBooks', () => {
+    it('chrome.runtime.sendMessage を正しい引数で呼ぶ', async () => {
+      const successResponse: SendScrapedBooksResponse = {
+        success: true,
+        data: { savedCount: 1, duplicateCount: 0, duplicates: [] },
+      }
+      mockSendMessage.mockResolvedValue(successResponse)
+
+      await sender.sendScrapedBooks(testBooks)
+
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        type: 'SEND_SCRAPED_BOOKS',
+        books: testBooks,
+      })
+    })
+
+    it('成功レスポンスをそのまま返す', async () => {
+      const successResponse: SendScrapedBooksResponse = {
+        success: true,
+        data: { savedCount: 1, duplicateCount: 0, duplicates: [] },
+      }
+      mockSendMessage.mockResolvedValue(successResponse)
+
+      const result = await sender.sendScrapedBooks(testBooks)
+      expect(result).toEqual(successResponse)
+    })
+
+    it('エラーレスポンスをそのまま返す', async () => {
+      const errorResponse: SendScrapedBooksResponse = {
+        success: false,
+        error: '未認証',
+        code: 'AUTH_ERROR',
+      }
+      mockSendMessage.mockResolvedValue(errorResponse)
+
+      const result = await sender.sendScrapedBooks(testBooks)
+      expect(result).toEqual(errorResponse)
+    })
+
+    it('chrome.runtime.lastError がある場合エラーを throw する', async () => {
+      Object.defineProperty(chrome.runtime, 'lastError', {
+        value: { message: 'Extension context invalidated' },
+        writable: true,
+        configurable: true,
+      })
+      mockSendMessage.mockResolvedValue(undefined)
+
+      await expect(sender.sendScrapedBooks(testBooks)).rejects.toThrow(
+        'Extension context invalidated',
+      )
+    })
+
+    it('sendMessage が undefined を返した場合エラーを throw する', async () => {
+      mockSendMessage.mockResolvedValue(undefined)
+
+      await expect(sender.sendScrapedBooks(testBooks)).rejects.toThrow()
+    })
+  })
+})

--- a/apps/extension/src/content/shared/__tests__/sender.test.ts
+++ b/apps/extension/src/content/shared/__tests__/sender.test.ts
@@ -7,7 +7,6 @@ const mockSendMessage = vi.fn()
 vi.stubGlobal('chrome', {
   runtime: {
     sendMessage: mockSendMessage,
-    lastError: null,
   },
 })
 
@@ -26,12 +25,6 @@ describe('sender', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
-    // lastError をリセット
-    Object.defineProperty(chrome.runtime, 'lastError', {
-      value: null,
-      writable: true,
-      configurable: true,
-    })
     sender = await import('../sender.js')
   })
 
@@ -74,16 +67,19 @@ describe('sender', () => {
       expect(result).toEqual(errorResponse)
     })
 
-    it('chrome.runtime.lastError がある場合エラーを throw する', async () => {
-      Object.defineProperty(chrome.runtime, 'lastError', {
-        value: { message: 'Extension context invalidated' },
-        writable: true,
-        configurable: true,
-      })
-      mockSendMessage.mockResolvedValue(undefined)
+    it('sendMessage が reject した場合エラーを throw する', async () => {
+      mockSendMessage.mockRejectedValue(new Error('Extension context invalidated'))
 
       await expect(sender.sendScrapedBooks(testBooks)).rejects.toThrow(
         'Extension context invalidated',
+      )
+    })
+
+    it('sendMessage が非 Error で reject した場合も throw する', async () => {
+      mockSendMessage.mockRejectedValue('unknown error')
+
+      await expect(sender.sendScrapedBooks(testBooks)).rejects.toThrow(
+        'Failed to contact background script',
       )
     })
 

--- a/apps/extension/src/content/shared/sender.ts
+++ b/apps/extension/src/content/shared/sender.ts
@@ -1,2 +1,19 @@
-// Web API (/api/scrape) への POST 処理
-// TODO: 認証ヘッダー付きの送信ロジックを実装 (#9)
+import type { ScrapeBook } from '@bookhub/shared'
+import type { SendScrapedBooksResponse } from '../../types/messages.js'
+
+export async function sendScrapedBooks(books: ScrapeBook[]): Promise<SendScrapedBooksResponse> {
+  const response: SendScrapedBooksResponse | undefined = await chrome.runtime.sendMessage({
+    type: 'SEND_SCRAPED_BOOKS',
+    books,
+  })
+
+  if (chrome.runtime.lastError) {
+    throw new Error(chrome.runtime.lastError.message)
+  }
+
+  if (response === undefined) {
+    throw new Error('Background script did not respond')
+  }
+
+  return response
+}

--- a/apps/extension/src/content/shared/sender.ts
+++ b/apps/extension/src/content/shared/sender.ts
@@ -2,13 +2,14 @@ import type { ScrapeBook } from '@bookhub/shared'
 import type { SendScrapedBooksResponse } from '../../types/messages.js'
 
 export async function sendScrapedBooks(books: ScrapeBook[]): Promise<SendScrapedBooksResponse> {
-  const response: SendScrapedBooksResponse | undefined = await chrome.runtime.sendMessage({
-    type: 'SEND_SCRAPED_BOOKS',
-    books,
-  })
-
-  if (chrome.runtime.lastError) {
-    throw new Error(chrome.runtime.lastError.message)
+  let response: SendScrapedBooksResponse | undefined
+  try {
+    response = await chrome.runtime.sendMessage({
+      type: 'SEND_SCRAPED_BOOKS',
+      books,
+    })
+  } catch (err) {
+    throw new Error(err instanceof Error ? err.message : 'Failed to contact background script')
   }
 
   if (response === undefined) {

--- a/apps/extension/src/env.d.ts
+++ b/apps/extension/src/env.d.ts
@@ -1,0 +1,1 @@
+declare const __API_BASE_URL__: string

--- a/apps/extension/src/popup/index.html
+++ b/apps/extension/src/popup/index.html
@@ -4,11 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BookHub</title>
+    <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
     <div id="app">
       <h1>BookHub</h1>
-      <p>TODO: ポップアップ UI を実装 (#9)</p>
+      <div id="auth-status" class="status"></div>
+      <div id="sync-status" class="status"></div>
+      <a id="bookshelf-link" href="#" target="_blank" class="link">本棚を開く</a>
     </div>
+    <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/apps/extension/src/popup/index.html
+++ b/apps/extension/src/popup/index.html
@@ -11,7 +11,7 @@
       <h1>BookHub</h1>
       <div id="auth-status" class="status"></div>
       <div id="sync-status" class="status"></div>
-      <a id="bookshelf-link" href="#" target="_blank" class="link">本棚を開く</a>
+      <a id="bookshelf-link" href="#" target="_blank" rel="noopener noreferrer" class="link">本棚を開く</a>
     </div>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/apps/extension/src/popup/main.ts
+++ b/apps/extension/src/popup/main.ts
@@ -1,0 +1,51 @@
+import { getAccessToken, getLastSyncResult } from '../utils/storage.js'
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const authStatusEl = document.getElementById('auth-status')
+  const syncStatusEl = document.getElementById('sync-status')
+  const bookshelfLink = document.getElementById('bookshelf-link') as HTMLAnchorElement | null
+
+  // 本棚リンク URL
+  if (bookshelfLink) {
+    bookshelfLink.href = `${__API_BASE_URL__}/bookshelf`
+  }
+
+  // 認証状態
+  if (authStatusEl) {
+    const token = await getAccessToken()
+    if (token) {
+      authStatusEl.textContent = 'ログイン中'
+      authStatusEl.className = 'status status-auth-ok'
+    } else {
+      authStatusEl.textContent = '未ログイン - Web アプリでログインしてください'
+      authStatusEl.className = 'status status-auth-none'
+    }
+  }
+
+  // 同期結果
+  if (syncStatusEl) {
+    const result = await getLastSyncResult()
+    if (!result) {
+      syncStatusEl.textContent = 'まだ同期が行われていません'
+      syncStatusEl.className = 'status status-none'
+      return
+    }
+
+    const date = new Date(result.timestamp).toLocaleString('ja-JP')
+
+    switch (result.status) {
+      case 'success':
+        syncStatusEl.textContent = `${result.savedCount}冊を同期しました（${date}）`
+        syncStatusEl.className = 'status status-success'
+        break
+      case 'partial':
+        syncStatusEl.textContent = `${result.savedCount}冊を同期しました（重複: ${result.duplicateCount}冊）（${date}）`
+        syncStatusEl.className = 'status status-partial'
+        break
+      case 'error':
+        syncStatusEl.textContent = `同期エラー: ${result.error ?? '不明なエラー'}（${date}）`
+        syncStatusEl.className = 'status status-error'
+        break
+    }
+  }
+})

--- a/apps/extension/src/popup/style.css
+++ b/apps/extension/src/popup/style.css
@@ -1,0 +1,78 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  width: 320px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #fff;
+}
+
+#app {
+  padding: 16px;
+}
+
+h1 {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: #2563eb;
+}
+
+.status {
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.status-success {
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.status-partial {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.status-error {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.status-none {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
+.status-auth-ok {
+  background: #eff6ff;
+  color: #1e40af;
+}
+
+.status-auth-none {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.link {
+  display: block;
+  text-align: center;
+  padding: 10px;
+  background: #2563eb;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 6px;
+  font-weight: 500;
+  margin-top: 4px;
+}
+
+.link:hover {
+  background: #1d4ed8;
+}

--- a/apps/extension/src/types/messages.ts
+++ b/apps/extension/src/types/messages.ts
@@ -1,0 +1,44 @@
+import type { ScrapeBook, ScrapeResponse, ScrapeDuplicate } from '@bookhub/shared'
+
+// --- エラーコード ---
+
+export type ErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'AUTH_ERROR'
+  | 'NETWORK_ERROR'
+  | 'API_ERROR'
+  | 'UNKNOWN_ERROR'
+
+// --- メッセージレスポンス（判別共用体） ---
+
+export type MessageResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; code: ErrorCode }
+
+// --- Content Script → Background メッセージ ---
+
+export interface SendScrapedBooksMessage {
+  type: 'SEND_SCRAPED_BOOKS'
+  books: ScrapeBook[]
+}
+
+export interface ReloadBookshelfMessage {
+  type: 'RELOAD_BOOKSHELF'
+}
+
+export type ExtensionMessage = SendScrapedBooksMessage | ReloadBookshelfMessage
+
+// --- 同期結果（storage 保存用） ---
+
+export interface SyncResult {
+  status: 'success' | 'partial' | 'error'
+  savedCount: number
+  duplicateCount: number
+  duplicates: ScrapeDuplicate[]
+  error?: string
+  timestamp: number
+}
+
+// --- Background → Content Script レスポンス型 ---
+
+export type SendScrapedBooksResponse = MessageResponse<ScrapeResponse>

--- a/apps/extension/src/utils/__tests__/storage.test.ts
+++ b/apps/extension/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { SyncResult } from '../../types/messages.js'
+
+// chrome.storage.session のモック
+const mockStorage = new Map<string, unknown>()
+
+const chromeStorageMock = {
+  storage: {
+    session: {
+      get: vi.fn((keys: string[]) => {
+        const result: Record<string, unknown> = {}
+        for (const key of keys) {
+          const value = mockStorage.get(key)
+          if (value !== undefined) {
+            result[key] = value
+          }
+        }
+        return Promise.resolve(result)
+      }),
+      set: vi.fn((items: Record<string, unknown>) => {
+        for (const [key, value] of Object.entries(items)) {
+          mockStorage.set(key, value)
+        }
+        return Promise.resolve()
+      }),
+      remove: vi.fn((keys: string[]) => {
+        for (const key of keys) {
+          mockStorage.delete(key)
+        }
+        return Promise.resolve()
+      }),
+    },
+  },
+}
+
+vi.stubGlobal('chrome', chromeStorageMock)
+
+describe('storage', () => {
+  let storage: typeof import('../storage.js')
+
+  beforeEach(async () => {
+    mockStorage.clear()
+    vi.clearAllMocks()
+    storage = await import('../storage.js')
+  })
+
+  describe('getAccessToken', () => {
+    it('トークンが保存されていない場合 null を返す', async () => {
+      const token = await storage.getAccessToken()
+      expect(token).toBeNull()
+    })
+
+    it('保存済みのトークンを返す', async () => {
+      mockStorage.set('bookhub_access_token', 'test-token-123')
+      const token = await storage.getAccessToken()
+      expect(token).toBe('test-token-123')
+    })
+  })
+
+  describe('setAccessToken', () => {
+    it('トークンを保存できる', async () => {
+      await storage.setAccessToken('my-token')
+      expect(mockStorage.get('bookhub_access_token')).toBe('my-token')
+    })
+
+    it('chrome.storage.session.set が正しい引数で呼ばれる', async () => {
+      await storage.setAccessToken('abc')
+      expect(chromeStorageMock.storage.session.set).toHaveBeenCalledWith({
+        bookhub_access_token: 'abc',
+      })
+    })
+  })
+
+  describe('removeAccessToken', () => {
+    it('トークンを削除できる', async () => {
+      mockStorage.set('bookhub_access_token', 'to-remove')
+      await storage.removeAccessToken()
+      expect(mockStorage.has('bookhub_access_token')).toBe(false)
+    })
+
+    it('chrome.storage.session.remove が正しい引数で呼ばれる', async () => {
+      await storage.removeAccessToken()
+      expect(chromeStorageMock.storage.session.remove).toHaveBeenCalledWith([
+        'bookhub_access_token',
+      ])
+    })
+  })
+
+  describe('getLastSyncResult', () => {
+    it('結果が保存されていない場合 null を返す', async () => {
+      const result = await storage.getLastSyncResult()
+      expect(result).toBeNull()
+    })
+
+    it('保存済みの同期結果を返す', async () => {
+      const syncResult: SyncResult = {
+        status: 'success',
+        savedCount: 5,
+        duplicateCount: 2,
+        duplicates: [{ title: 'テスト漫画', existingStores: ['kindle'] }],
+        timestamp: Date.now(),
+      }
+      mockStorage.set('bookhub_last_sync_result', syncResult)
+
+      const result = await storage.getLastSyncResult()
+      expect(result).toEqual(syncResult)
+    })
+  })
+
+  describe('setLastSyncResult', () => {
+    it('同期結果を保存できる', async () => {
+      const syncResult: SyncResult = {
+        status: 'error',
+        savedCount: 0,
+        duplicateCount: 0,
+        duplicates: [],
+        error: 'ネットワークエラー',
+        timestamp: Date.now(),
+      }
+      await storage.setLastSyncResult(syncResult)
+      expect(mockStorage.get('bookhub_last_sync_result')).toEqual(syncResult)
+    })
+  })
+})

--- a/apps/extension/src/utils/storage.ts
+++ b/apps/extension/src/utils/storage.ts
@@ -1,2 +1,28 @@
-// chrome.storage ラッパー（認証トークン等）
-// TODO: 実装 (#9)
+import type { SyncResult } from '../types/messages.js'
+
+const STORAGE_KEYS = {
+  ACCESS_TOKEN: 'bookhub_access_token',
+  LAST_SYNC_RESULT: 'bookhub_last_sync_result',
+} as const
+
+export async function getAccessToken(): Promise<string | null> {
+  const result = await chrome.storage.session.get([STORAGE_KEYS.ACCESS_TOKEN])
+  return (result[STORAGE_KEYS.ACCESS_TOKEN] as string | undefined) ?? null
+}
+
+export async function setAccessToken(token: string): Promise<void> {
+  await chrome.storage.session.set({ [STORAGE_KEYS.ACCESS_TOKEN]: token })
+}
+
+export async function removeAccessToken(): Promise<void> {
+  await chrome.storage.session.remove([STORAGE_KEYS.ACCESS_TOKEN])
+}
+
+export async function getLastSyncResult(): Promise<SyncResult | null> {
+  const result = await chrome.storage.session.get([STORAGE_KEYS.LAST_SYNC_RESULT])
+  return (result[STORAGE_KEYS.LAST_SYNC_RESULT] as SyncResult | undefined) ?? null
+}
+
+export async function setLastSyncResult(syncResult: SyncResult): Promise<void> {
+  await chrome.storage.session.set({ [STORAGE_KEYS.LAST_SYNC_RESULT]: syncResult })
+}

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -4,6 +4,9 @@ import manifest from './manifest.config'
 
 export default defineConfig({
   plugins: [crx({ manifest })],
+  define: {
+    __API_BASE_URL__: JSON.stringify(process.env.BOOKHUB_API_URL || 'http://localhost:3000'),
+  },
   server: {
     cors: {
       origin: [/chrome-extension:\/\//],

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -2,10 +2,21 @@ import { defineConfig } from 'vite'
 import { crx } from '@crxjs/vite-plugin'
 import manifest from './manifest.config'
 
+const apiUrl = process.env.BOOKHUB_API_URL || 'http://localhost:3000'
+
+if (process.env.NODE_ENV === 'production') {
+  if (!process.env.BOOKHUB_API_URL) {
+    throw new Error('BOOKHUB_API_URL must be set for production builds')
+  }
+  if (!apiUrl.startsWith('https://')) {
+    throw new Error('BOOKHUB_API_URL must use HTTPS for production builds')
+  }
+}
+
 export default defineConfig({
   plugins: [crx({ manifest })],
   define: {
-    __API_BASE_URL__: JSON.stringify(process.env.BOOKHUB_API_URL || 'http://localhost:3000'),
+    __API_BASE_URL__: JSON.stringify(apiUrl),
   },
   server: {
     cors: {

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -2,25 +2,29 @@ import { defineConfig } from 'vite'
 import { crx } from '@crxjs/vite-plugin'
 import manifest from './manifest.config'
 
-const apiUrl = process.env.BOOKHUB_API_URL || 'http://localhost:3000'
+// mode=production（`vite build --mode production`）のときのみ HTTPS を強制
+// 通常の `vite build` は mode=production だが、開発用ビルドでは `--mode development` を使う
+export default defineConfig(({ mode }) => {
+  const apiUrl = process.env.BOOKHUB_API_URL || 'http://localhost:3000'
 
-if (process.env.NODE_ENV === 'production') {
-  if (!process.env.BOOKHUB_API_URL) {
-    throw new Error('BOOKHUB_API_URL must be set for production builds')
+  if (mode === 'production') {
+    if (!process.env.BOOKHUB_API_URL) {
+      throw new Error('BOOKHUB_API_URL must be set for production builds')
+    }
+    if (!apiUrl.startsWith('https://')) {
+      throw new Error('BOOKHUB_API_URL must use HTTPS for production builds')
+    }
   }
-  if (!apiUrl.startsWith('https://')) {
-    throw new Error('BOOKHUB_API_URL must use HTTPS for production builds')
-  }
-}
 
-export default defineConfig({
-  plugins: [crx({ manifest })],
-  define: {
-    __API_BASE_URL__: JSON.stringify(apiUrl),
-  },
-  server: {
-    cors: {
-      origin: [/chrome-extension:\/\//],
+  return {
+    plugins: [crx({ manifest })],
+    define: {
+      __API_BASE_URL__: JSON.stringify(apiUrl),
     },
-  },
+    server: {
+      cors: {
+        origin: [/chrome-extension:\/\//],
+      },
+    },
+  }
 })

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts'],
+    environment: 'node',
+    mockReset: true,
+  },
+})

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,10 +67,15 @@ cp .env.example apps/web/.env.local
 
 ### apps/extension
 
-| コマンド                        | 説明                             |
-| ------------------------------- | -------------------------------- |
-| `pnpm --filter extension dev`   | 拡張機能の開発ビルド（HMR あり） |
-| `pnpm --filter extension build` | 拡張機能の本番ビルド             |
+| コマンド                                | 説明                                                    |
+| --------------------------------------- | ------------------------------------------------------- |
+| `pnpm --filter extension dev`           | 拡張機能の開発ビルド（HMR あり、localhost:3000 を使用） |
+| `pnpm --filter extension build`         | 拡張機能の開発用ビルド（`--mode development`）          |
+| `pnpm --filter extension build:prod`    | 拡張機能の本番ビルド（`--mode production`、HTTPS 必須） |
+| `pnpm --filter extension lint`          | ESLint でコード品質をチェック                           |
+| `pnpm --filter extension test`          | ユニットテストを実行                                    |
+| `pnpm --filter extension test:watch`    | ユニットテストをウォッチモードで実行                    |
+| `pnpm --filter extension test:coverage` | テストカバレッジレポート生成                            |
 
 ### packages/shared
 
@@ -79,6 +84,8 @@ cp .env.example apps/web/.env.local
 | `pnpm --filter @bookhub/shared build` | 型定義・スキーマをビルド |
 
 ## 環境変数リファレンス
+
+### Web アプリ （apps/web）
 
 <!-- AUTO-GENERATED: generated from .env.example -->
 
@@ -92,6 +99,28 @@ cp .env.example apps/web/.env.local
 
 \*書籍情報 API はどちらか一方が必要
 
+### Chrome 拡張機能 （apps/extension）
+
+| 変数              | 必須  | 説明                                                       |
+| ----------------- | ----- | ---------------------------------------------------------- |
+| `BOOKHUB_API_URL` | Yes\* | Web API ベース URL（ビルド時に指定、ビルドに埋め込まれる） |
+
+\* 開発時: `localhost:3000`、本番ビルド時: HTTPS な本番 URL（必須）
+
+#### 設定方法
+
+**開発時:**
+
+```bash
+BOOKHUB_API_URL=http://localhost:3000 pnpm --filter extension dev
+```
+
+**本番ビルド時:**
+
+```bash
+BOOKHUB_API_URL=https://bookshelf.example.com pnpm --filter extension build:prod
+```
+
 <!-- /AUTO-GENERATED -->
 
 ## テスト
@@ -104,6 +133,7 @@ pnpm test
 
 # 特定のパッケージのみ実行
 pnpm --filter web test
+pnpm --filter extension test
 pnpm --filter @bookhub/shared test
 
 # ウォッチモード（ファイル変更時に自動再実行）
@@ -127,6 +157,30 @@ pnpm test:coverage
 | **Unit**        | 関数・クラス         | `processScrapePayload()`, Zod スキーマ検証                 |
 | **Integration** | API エンドポイント   | `POST /api/scrape` の認証 + バリデーション + Supabase 連携 |
 | **Middleware**  | Next.js ミドルウェア | Cookie 認証、ルート保護                                    |
+| **Extension**   | Chrome 拡張機能      | メッセージハンドリング、ストレージ操作、API 通信           |
+
+### Chrome 拡張機能テスト
+
+拡張機能のテストでは、`chrome` グローバルオブジェクトをモック化して実行します：
+
+```bash
+# 拡張機能テストの実行
+pnpm --filter extension test
+
+# ウォッチモード
+pnpm --filter extension test:watch
+
+# カバレッジレポート
+pnpm --filter extension test:coverage
+```
+
+**テスト範囲:**
+
+- Service Worker メッセージハンドリング
+- Content Script ↔ Background 通信
+- Token ライフサイクル（取得・保存・削除）
+- API エラーハンドリング（401/400/500）
+- 本棚タブリロード動作
 
 ## API エンドポイントリファレンス
 
@@ -350,6 +404,47 @@ Authorization: Bearer <token>
 - husky の pre-commit フックにより、コミット時に `pnpm lint` と `pnpm format:check` が自動実行される
 - コミット前に `pnpm fix` を実行して問題を解消しておくことを推奨
 
+## Extension 開発ガイド
+
+### メッセージ型定義
+
+Content Script と Service Worker の通信は `src/types/messages.ts` で定義された型セーフなメッセージを使用します：
+
+```typescript
+// Content Script から送信
+const response = await sendScrapedBooks(books)
+
+// Service Worker で受信
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  handleMessage(message, sender).then(sendResponse)
+  return true // 非同期レスポンス有効化
+})
+```
+
+### ストレージ操作
+
+トークン・同期結果の保存は `src/utils/storage.ts` の関数を使用：
+
+```typescript
+// トークン取得
+const token = await getAccessToken()
+
+// 同期結果保存
+await setLastSyncResult({ status: 'success', savedCount: 1, ... })
+```
+
+### ローカルテスト
+
+```bash
+# 1. Web アプリをローカル実行
+NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... pnpm --filter web dev
+
+# 2. 拡張機能を開発ビルド
+BOOKHUB_API_URL=http://localhost:3000 pnpm --filter extension dev
+
+# 3. Chrome で chrome://extensions を開き、dist/ フォルダをロード
+```
+
 ## PR チェックリスト
 
 - [ ] `pnpm build` が通る
@@ -358,3 +453,8 @@ Authorization: Bearer <token>
 - [ ] `pnpm format:check` が通る
 - [ ] 関連 Issue 番号をコミットメッセージまたは PR 本文に記載
 - [ ] API エンドポイント変更の場合は本セクションの「API エンドポイントリファレンス」を更新
+- [ ] Chrome 拡張機能変更の場合は以下を確認：
+  - [ ] メッセージ型定義が `src/types/messages.ts` で正しく定義されている
+  - [ ] `handleMessage()` の sender.id 検証が実装されている
+  - [ ] エラーハンドリング（AUTH_ERROR/VALIDATION_ERROR/API_ERROR）が完備されている
+  - [ ] Storage 操作に `src/utils/storage.ts` の関数を使用している

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,21 +102,87 @@ hons/
 
 ---
 
-## 4. 設計判断の根拠
+## 4. Chrome 拡張機能の通信フロー
 
-| 判断                                       | 理由                                                            |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| pnpm workspaces モノレポ                   | `packages/shared` で型・スキーマ共有。Turborepoは現段階では過剰 |
-| `(auth)` / `(protected)` ルートグループ    | 認証済み・未認証で layout と保護を分離                          |
-| `lib/supabase/` を3ファイルに分割          | Cloudflare Edge Runtime + `@supabase/ssr` の推奨パターン        |
-| `components/layout/` と `features/` を分離 | layoutは構造的関心事、featuresは機能的関心事                    |
-| `duplicate-alert/` はUIのみ                | 重複検知ロジックは `api/scrape` サーバー側に置く                |
-| `extension/content/shared/`                | ストアをまたぐパース・API送信ロジックをDRY化                    |
-| `packages/shared/schemas/` にZodスキーマ   | Extension→Web API間のデータ整合性を両側で保証                   |
+拡張機能は Manifest V3 の Service Worker ベースアーキテクチャを採用。Content Script ↔ Service Worker 間の通信は、型安全なメッセージを使用します。
+
+### メッセージ型（src/types/messages.ts）
+
+```typescript
+// Content Script から Service Worker へ
+type SendScrapedBooksMessage = {
+  type: 'SEND_SCRAPED_BOOKS'
+  books: ScrapeBook[]
+}
+
+type ReloadBookshelfMessage = {
+  type: 'RELOAD_BOOKSHELF'
+}
+
+type ExtensionMessage = SendScrapedBooksMessage | ReloadBookshelfMessage
+
+// Service Worker からのレスポンス（共通形式）
+type MessageResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; code: ErrorCode }
+
+type ErrorCode = 'VALIDATION_ERROR' | 'AUTH_ERROR' | 'API_ERROR' | 'NETWORK_ERROR' | 'UNKNOWN_ERROR'
+```
+
+### 通信フロー
+
+1. **Content Script** (Kindle / DMM ページ)
+   - DOM をスクレイピング → `ScrapeBook[]` に正規化
+   - `chrome.runtime.sendMessage()` で Service Worker へ送信
+   - Bearer トークンは Service Worker が保有（Content Script は知らない）
+
+2. **Service Worker** (background/index.ts)
+   - `chrome.runtime.onMessage` で受信
+   - メッセージ型を型ガード `isValidMessage()` で検証
+   - `sender.id === chrome.runtime.id` で送信元検証（セキュリティ）
+   - Zod スキーマで payload をバリデーション
+   - `/api/scrape` へ Bearer トークン付きで POST
+   - 同期結果を `chrome.storage.session` に保存
+   - 本棚タブを自動リロード
+   - Response を Content Script へ返信
+
+3. **API エンドポイント** (/api/scrape)
+   - Bearer トークンで認証
+   - バリデーションスキーマで payload 検証
+   - 重複検知 → Supabase へ保存
+   - 結果を JSON で返信
+
+### エラーハンドリング
+
+```typescript
+// 各エラーケースは ErrorCode で分類
+API 401 → AUTH_ERROR (再ログイン必要)
+API 400 → VALIDATION_ERROR (バリデーション失敗)
+API 500 → API_ERROR (サーバーエラー)
+Network error → NETWORK_ERROR (接続失敗)
+Invalid message → UNKNOWN_ERROR (不明なメッセージ)
+Foreign sender → UNKNOWN_ERROR (送信元検証失敗)
+```
 
 ---
 
-## 5. Cloudflare Pages Edge Runtime の制約
+## 6. 設計判断の根拠
+
+| 判断                                       | 理由                                                               |
+| ------------------------------------------ | ------------------------------------------------------------------ |
+| pnpm workspaces モノレポ                   | `packages/shared` で型・スキーマ共有。Turborepoは現段階では過剰    |
+| `(auth)` / `(protected)` ルートグループ    | 認証済み・未認証で layout と保護を分離                             |
+| `lib/supabase/` を3ファイルに分割          | Cloudflare Edge Runtime + `@supabase/ssr` の推奨パターン           |
+| `components/layout/` と `features/` を分離 | layoutは構造的関心事、featuresは機能的関心事                       |
+| `duplicate-alert/` はUIのみ                | 重複検知ロジックは `api/scrape` サーバー側に置く                   |
+| `extension/content/shared/`                | ストアをまたぐパース・API送信ロジックをDRY化                       |
+| `packages/shared/schemas/` にZodスキーマ   | Extension→Web API間のデータ整合性を両側で保証                      |
+| 型ガード `isValidMessage()`                | Content Script からの未検証 payload を Service Worker が安全に処理 |
+| `sender.id === chrome.runtime.id`          | 悪意あるコンテンツスクリプトからのメッセージを拒否                 |
+
+---
+
+## 7. Cloudflare Pages Edge Runtime の制約
 
 - Node.js固有API（`fs`、`Buffer`の一部等）は使用不可
 - 各Route Handlerファイルに `export const runtime = 'edge'` が必要
@@ -125,9 +191,11 @@ hons/
 
 ---
 
-## 6. 環境変数
+## 8. 環境変数
 
-`.env.example` をルートに配置し、チーム共有用テンプレートとする。実際の値は `apps/web/.env.local` に記載（gitignore対象）。
+`.env.example` をルートに配置し、チーム共有用テンプレートとする。実際の値は以下のように設定します。
+
+### Web アプリ (apps/web/.env.local)
 
 ```env
 # Supabase
@@ -140,9 +208,19 @@ RAKUTEN_APP_ID=
 GOOGLE_BOOKS_API_KEY=
 ```
 
+### Chrome 拡張機能 (ビルド時)
+
+```bash
+# 開発時
+BOOKHUB_API_URL=http://localhost:3000 pnpm --filter extension dev
+
+# 本番時（HTTPS 必須）
+BOOKHUB_API_URL=https://bookshelf.example.com pnpm --filter extension build:prod
+```
+
 ---
 
-## 7. データベーススキーマ
+## 9. データベーススキーマ
 
 詳細なテーブル定義、制約、RLS ポリシー、トリガーについては **[DB_SCHEMA.md](./DB_SCHEMA.md)** を参照してください。
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.58.1
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: ^10.2.0
         version: 10.2.0(jiti@2.6.1)
@@ -45,6 +48,9 @@ importers:
       vite:
         specifier: ^6.3.3
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -105,7 +111,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: ^16.2.3
-        version: 16.2.3(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.4
         version: 4.2.2
@@ -7238,13 +7244,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.3(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.2.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -7266,7 +7272,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7277,22 +7283,21 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7303,7 +7308,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7314,8 +7319,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## 概要

Issue #9「Chrome 拡張機能の基盤を構築」の実装。Manifest V3 ベースの Chrome 拡張機能を TDD で段階的に実装し、Web アプリ（Next.js）への書籍データ送信フローを確立した。

## 変更内容

### 実装（5 フェーズ）

- **Phase 1**: メッセージ型定義（`src/types/messages.ts`）と `chrome.storage` ラッパー（`src/utils/storage.ts`）
- **Phase 2**: Vite define による API Base URL のビルド時注入（`__API_BASE_URL__`）と `src/env.d.ts`
- **Phase 3**: Content Script ↔ Service Worker 通信レイヤー（`sender.ts` と `background/index.ts`）
- **Phase 4**: ポップアップ UI（同期ステータス表示、本棚リンク）
- **Phase 5**: manifest 設定調整とテスト環境整備（vitest.config.ts, package.json）

### セキュリティ修正

- `sender.id === chrome.runtime.id` チェックによる送信元検証（未検証だと悪意あるページからメッセージを受信できた）
- production ビルドの HTTPS 強制を `NODE_ENV` ではなく Vite の `mode` で判定（`--mode development` で開発ビルドが可能に）

### コード品質修正

- 型ガード `isValidMessage()` で未検証 payload の型安全化
- `SyncResult.status` の判定ロジック修正（全重複時を `partial` に正しく分類）
- `chrome.runtime.lastError` のデッドコード削除 → Promise 形式の `try/catch` に変更
- `reloadBookshelfTabs()` のハードコードされた localhost URL を `__API_BASE_URL__` に統一

### ドキュメント更新

- `CONTRIBUTING.md`: Extension 全コマンド、`BOOKHUB_API_URL` 環境変数、テストガイド、PR チェックリスト
- `architecture.md`: 通信フロー（メッセージ型・エラーハンドリング）と設計判断を追記
- `CLAUDE.md`: Extension 開発コマンドクイックリファレンス

## テスト

31 件のユニットテストをすべて通過（TDD で実装）：

- `background/__tests__/index.test.ts`: Service Worker メッセージハンドリング（17 件）
- `content/shared/__tests__/sender.test.ts`: Content Script → Background 通信（7 件）
- `utils/__tests__/storage.test.ts`: `chrome.storage.session` ラッパー（9 件） 

## Test plan

- [ ] `pnpm --filter extension test` が 31 件通過することを確認
- [ ] `pnpm build` でビルドが通ることを確認
- [ ] `pnpm lint` が通ることを確認
- [ ] Chrome で `dist/` フォルダをロードし、ポップアップ UI が表示されることを確認
- [ ] `BOOKHUB_API_URL=https://...` で `build:prod` が HTTPS のみ受け付けることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 拡張機能ポップアップUIを追加（認証状況・同期結果表示、本棚リンク）
  * コンテンツ→背景への書籍送信フローを実装（送信API連携、同期結果保存、成功時に本棚タブを再読み込み）
  * ストレージ操作APIとメッセージ型定義を導入

* **Tests**
  * 背景/送信/ストレージ周りの包括的なユニットテストを追加

* **Documentation**
  * 拡張機能開発ガイド・コマンド・環境変数情報を拡充

* **Chores**
  * ビルド/テストスクリプトとテスト設定を追加・整理
<!-- end of auto-generated comment: release notes by coderabbit.ai -->