### PR TITLE
feat: 本棚をシリーズ一覧+巻詳細の二階層 UI に再構成 (#33)

### DIFF
--- a/apps/web/app/(protected)/bookshelf/__tests__/page.test.tsx
+++ b/apps/web/app/(protected)/bookshelf/__tests__/page.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react'
-import type { GetBooksResponse, BookWithStore } from '@bookhub/shared'
+import type { GetUserSeriesResult, UserSeries } from '@/lib/books/get-user-series'
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }))
 
-vi.mock('@/lib/books/get-user-books', () => ({
-  getUserBooks: vi.fn(),
+vi.mock('@/lib/books/get-user-series', () => ({
+  getUserSeries: vi.fn(),
 }))
 
 // BookSearchForm は Client Component のため next/navigation を使う。
@@ -18,25 +18,20 @@ vi.mock('next/navigation', () => ({
 }))
 
 import { createClient } from '@/lib/supabase/server'
-import { getUserBooks } from '@/lib/books/get-user-books'
+import { getUserSeries } from '@/lib/books/get-user-series'
 import BookshelfPage from '../page'
 
 const mockUser = { id: 'user-123', email: 'test@example.com' }
 
-function makeBook(overrides: Partial<BookWithStore> = {}): BookWithStore {
+function makeSeries(overrides: Partial<UserSeries> = {}): UserSeries {
   return {
-    id: '11111111-1111-1111-1111-111111111111',
-    title: 'Title',
-    author: 'Author',
-    volumeNumber: 1,
-    thumbnailUrl: null,
-    isbn: null,
-    publishedAt: null,
-    isAdult: false,
-    createdAt: '2024-01-01T00:00:00.000Z',
-    userBookId: '22222222-2222-2222-2222-222222222222',
-    store: 'kindle',
-    userBookCreatedAt: '2024-01-01T00:00:00.000Z',
+    seriesId: '11111111-1111-1111-1111-111111111111',
+    title: 'シリーズ',
+    author: '著者',
+    volumeCount: 10,
+    coverThumbnailUrl: null,
+    stores: ['kindle'],
+    lastAddedAt: '2024-01-01T00:00:00.000Z',
     ...overrides,
   }
 }
@@ -62,93 +57,86 @@ describe('BookshelfPage', () => {
     setupAuth()
   })
 
-  it('getUserBooks の結果をギャラリーに描画する', async () => {
-    const books = [
-      makeBook({
-        userBookId: '00000000-0000-0000-0000-0000000000a1',
-        title: 'ワンピース',
-        volumeNumber: 105,
-      }),
-      makeBook({
-        userBookId: '00000000-0000-0000-0000-0000000000a2',
-        title: 'NARUTO',
-        volumeNumber: 72,
-        store: 'dmm',
-      }),
+  it('getUserSeries の結果をシリーズギャラリーに描画する', async () => {
+    const series = [
+      makeSeries({ seriesId: 's-1', title: 'ワンピース', author: '尾田栄一郎', volumeCount: 105 }),
+      makeSeries({ seriesId: 's-2', title: 'NARUTO', author: '岸本斉史', volumeCount: 72 }),
     ]
-    const response: GetBooksResponse = { books, total: 2, page: 1, limit: 100 }
-    vi.mocked(getUserBooks).mockResolvedValue(response)
+    const response: GetUserSeriesResult = { series, total: 2, page: 1, limit: 100 }
+    vi.mocked(getUserSeries).mockResolvedValue(response)
 
     await renderPage()
 
     expect(screen.getByRole('heading', { name: '本棚' })).toBeInTheDocument()
-    expect(screen.getByText('2 冊')).toBeInTheDocument()
-    expect(screen.getByText('ワンピース (105巻)')).toBeInTheDocument()
-    expect(screen.getByText('NARUTO (72巻)')).toBeInTheDocument()
+    expect(screen.getByText('2 シリーズ')).toBeInTheDocument()
+    expect(screen.getByText('ワンピース')).toBeInTheDocument()
+    expect(screen.getByText('NARUTO')).toBeInTheDocument()
+    expect(screen.getByText('105 巻所持')).toBeInTheDocument()
+    expect(screen.getByText('72 巻所持')).toBeInTheDocument()
   })
 
-  it('books が空のときは empty state を表示する', async () => {
-    vi.mocked(getUserBooks).mockResolvedValue({ books: [], total: 0, page: 1, limit: 100 })
+  it('series が空のときは empty state を表示する', async () => {
+    vi.mocked(getUserSeries).mockResolvedValue({ series: [], total: 0, page: 1, limit: 100 })
 
     await renderPage()
 
     expect(screen.getByText('蔵書がまだありません')).toBeInTheDocument()
   })
 
-  it('searchParams.q が 2 文字以上のとき getUserBooks に q を渡す', async () => {
-    vi.mocked(getUserBooks).mockResolvedValue({ books: [], total: 0, page: 1, limit: 100 })
+  it('searchParams.q が 2 文字以上のとき getUserSeries に q を渡す', async () => {
+    vi.mocked(getUserSeries).mockResolvedValue({ series: [], total: 0, page: 1, limit: 100 })
 
     await renderPage({ q: 'ワンピ' })
 
-    expect(getUserBooks).toHaveBeenCalledWith(
+    expect(getUserSeries).toHaveBeenCalledWith(
       expect.anything(),
       'user-123',
       expect.objectContaining({ q: 'ワンピ', page: 1, limit: 100 }),
     )
   })
 
-  it('searchParams.q が 1 文字のとき getUserBooks には q を渡さない', async () => {
-    vi.mocked(getUserBooks).mockResolvedValue({ books: [], total: 0, page: 1, limit: 100 })
+  it('searchParams.q が 1 文字のとき getUserSeries には q を渡さない', async () => {
+    vi.mocked(getUserSeries).mockResolvedValue({ series: [], total: 0, page: 1, limit: 100 })
 
     await renderPage({ q: 'ワ' })
 
-    const call = vi.mocked(getUserBooks).mock.calls[0]
+    const call = vi.mocked(getUserSeries).mock.calls[0]
     expect(call?.[2]).not.toHaveProperty('q')
     expect(call?.[2]).toEqual(expect.objectContaining({ page: 1, limit: 100 }))
   })
 
-  it('searchParams.q が空文字列のとき getUserBooks には q を渡さない', async () => {
-    vi.mocked(getUserBooks).mockResolvedValue({ books: [], total: 0, page: 1, limit: 100 })
+  it('searchParams.q が空文字列のとき getUserSeries には q を渡さない', async () => {
+    vi.mocked(getUserSeries).mockResolvedValue({ series: [], total: 0, page: 1, limit: 100 })
 
     await renderPage({ q: '' })
 
-    const call = vi.mocked(getUserBooks).mock.calls[0]
+    const call = vi.mocked(getUserSeries).mock.calls[0]
     expect(call?.[2]).not.toHaveProperty('q')
   })
 
-  it('searchParams.q が空白のみのとき getUserBooks には q を渡さない', async () => {
-    vi.mocked(getUserBooks).mockResolvedValue({ books: [], total: 0, page: 1, limit: 100 })
+  it('searchParams.q が空白のみのとき getUserSeries には q を渡さない', async () => {
+    vi.mocked(getUserSeries).mockResolvedValue({ series: [], total: 0, page: 1, limit: 100 })
 
     await renderPage({ q: '   ' })
 
-    const call = vi.mocked(getUserBooks).mock.calls[0]
+    const call = vi.mocked(getUserSeries).mock.calls[0]
     expect(call?.[2]).not.toHaveProperty('q')
   })
 
-  it('searchParams.q が 200 文字を超える場合は 200 文字に切り詰めて getUserBooks に渡す', async () => {
-    vi.mocked(getUserBooks).mockResolvedValue({ books: [], total: 0, page: 1, limit: 100 })
+  it('searchParams.q が 200 文字を超える場合は 200 文字に切り詰めて getUserSeries に渡す', async () => {
+    vi.mocked(getUserSeries).mockResolvedValue({ series: [], total: 0, page: 1, limit: 100 })
 
     const longQ = 'あ'.repeat(500)
     await renderPage({ q: longQ })
 
-    const call = vi.mocked(getUserBooks).mock.calls[0]
+    const call = vi.mocked(getUserSeries).mock.calls[0]
     const passedQ = (call?.[2] as { q?: string }).q
     expect(passedQ?.length).toBe(200)
     expect(passedQ).toBe('あ'.repeat(200))
   })
 
   it('searchParams.q 2文字以上 & 結果 0 件のとき no-results を表示する', async () => {
-    vi.mocked(getUserBooks).mockResolvedValue({ books: [], total: 0, page: 1, limit: 100 })
+    vi.mocked(getUserSeries).mockResolvedValue({ series: [], total: 0, page: 1, limit: 100 })
 
     await renderPage({ q: 'ワンピ' })
 

--- a/apps/web/app/(protected)/bookshelf/loading.tsx
+++ b/apps/web/app/(protected)/bookshelf/loading.tsx
@@ -1,0 +1,19 @@
+export default function BookshelfLoading() {
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-8" aria-busy="true">
+      <div className="mb-6 flex items-baseline justify-between">
+        <div className="h-7 w-24 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+      </div>
+      <div className="mb-6 h-9 w-full max-w-md animate-pulse rounded bg-muted" />
+      <ul
+        aria-label="読み込み中"
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      >
+        {Array.from({ length: 10 }).map((_, i) => (
+          <li key={i} className="aspect-[2/3] animate-pulse rounded bg-muted" />
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/bookshelf/page.tsx
+++ b/apps/web/app/(protected)/bookshelf/page.tsx
@@ -1,8 +1,7 @@
 import { redirect } from 'next/navigation'
-import type { GetBooksQuery } from '@bookhub/shared'
 import { createClient } from '@/lib/supabase/server'
-import { getUserBooks } from '@/lib/books/get-user-books'
-import { BookGallery } from '@/features/bookshelf/book-gallery'
+import { getUserSeries } from '@/lib/books/get-user-series'
+import { SeriesGallery } from '@/features/bookshelf/series-gallery'
 import { BookSearchForm } from '@/features/bookshelf/book-search-form'
 import { EmptyState } from '@/features/bookshelf/empty-state'
 
@@ -11,7 +10,7 @@ import { EmptyState } from '@/features/bookshelf/empty-state'
 export const dynamic = 'force-dynamic'
 
 const MIN_QUERY_LENGTH = 2
-// getBooksQuerySchema.q の max(200) と同値にする (SC は直接 getUserBooks を呼ぶため
+// getBooksQuerySchema.q の max(200) と同値にする (SC は直接 getUserSeries を呼ぶため
 // zod schema を通らない。悪意ある長文クエリによる DoS 耐性として明示的に切り詰める)
 const MAX_QUERY_LENGTH = 200
 const DEFAULT_LIMIT = 100
@@ -36,23 +35,21 @@ export default async function BookshelfPage({ searchParams }: BookshelfPageProps
     redirect('/login')
   }
 
-  const query: GetBooksQuery = {
+  const { series, total } = await getUserSeries(supabase, user.id, {
     page: 1,
     limit: DEFAULT_LIMIT,
     ...(hasQuery ? { q: trimmed } : {}),
-  }
-
-  const { books, total } = await getUserBooks(supabase, user.id, query)
+  })
 
   return (
     <main className="mx-auto w-full max-w-7xl px-4 py-8">
       <header className="mb-6 flex items-baseline justify-between">
         <h1 className="text-2xl font-bold">本棚</h1>
-        <p className="text-sm text-muted-foreground">{total} 冊</p>
+        <p className="text-sm text-muted-foreground">{total} シリーズ</p>
       </header>
       <BookSearchForm defaultValue={trimmed} />
-      <BookGallery
-        books={books}
+      <SeriesGallery
+        series={series}
         emptyFallback={<EmptyState variant={hasQuery ? 'no-results' : 'empty'} />}
       />
     </main>

--- a/apps/web/app/(protected)/bookshelf/page.tsx
+++ b/apps/web/app/(protected)/bookshelf/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server'
 import { getUserBooks } from '@/lib/books/get-user-books'
 import { BookGallery } from '@/features/bookshelf/book-gallery'
 import { BookSearchForm } from '@/features/bookshelf/book-search-form'
+import { EmptyState } from '@/features/bookshelf/empty-state'
 
 // TODO: revalidateTag + unstable_cache に移行する (docs/specs/architecture.md 参照)
 // 現状は拡張機能のスクレイプ後リロードで最新データが出れば要件充足のため force-dynamic で許容
@@ -50,7 +51,10 @@ export default async function BookshelfPage({ searchParams }: BookshelfPageProps
         <p className="text-sm text-muted-foreground">{total} 冊</p>
       </header>
       <BookSearchForm defaultValue={trimmed} />
-      <BookGallery books={books} isSearching={hasQuery} />
+      <BookGallery
+        books={books}
+        emptyFallback={<EmptyState variant={hasQuery ? 'no-results' : 'empty'} />}
+      />
     </main>
   )
 }

--- a/apps/web/app/(protected)/bookshelf/page.tsx
+++ b/apps/web/app/(protected)/bookshelf/page.tsx
@@ -10,8 +10,9 @@ import { EmptyState } from '@/features/bookshelf/empty-state'
 export const dynamic = 'force-dynamic'
 
 const MIN_QUERY_LENGTH = 2
-// getBooksQuerySchema.q の max(200) と同値にする (SC は直接 getUserSeries を呼ぶため
-// zod schema を通らない。悪意ある長文クエリによる DoS 耐性として明示的に切り詰める)
+// `getUserSeries` の q は zod schema を経由しない (SC が直接呼ぶため)。
+// 悪意ある長文クエリによる DoS 耐性として API 側 `getBooksQuerySchema.q` の max(200) と
+// 同値で明示的に切り詰める。
 const MAX_QUERY_LENGTH = 200
 const DEFAULT_LIMIT = 100
 

--- a/apps/web/app/(protected)/bookshelf/series/[id]/__tests__/page.test.tsx
+++ b/apps/web/app/(protected)/bookshelf/series/[id]/__tests__/page.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from '@testing-library/react'
+import type { BookWithStore } from '@bookhub/shared'
+import type { SeriesDetail } from '@/lib/books/get-series-detail'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/books/get-series-detail', () => ({
+  getSeriesDetail: vi.fn(),
+}))
+
+const notFoundMock = vi.fn(() => {
+  throw new Error('NEXT_NOT_FOUND')
+})
+const redirectMock = vi.fn(() => {
+  throw new Error('NEXT_REDIRECT')
+})
+
+vi.mock('next/navigation', () => ({
+  notFound: () => notFoundMock(),
+  redirect: () => redirectMock(),
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { getSeriesDetail } from '@/lib/books/get-series-detail'
+import SeriesDetailPage from '../page'
+
+const mockUser = { id: 'user-123', email: 'test@example.com' }
+const validSeriesId = '11111111-1111-1111-1111-111111111111'
+
+function makeVolume(overrides: Partial<BookWithStore> = {}): BookWithStore {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    title: 'ワンピース',
+    author: '尾田栄一郎',
+    volumeNumber: 1,
+    thumbnailUrl: null,
+    isbn: null,
+    publishedAt: null,
+    isAdult: false,
+    createdAt: '2024-01-01T00:00:00Z',
+    userBookId: 'ub-1',
+    store: 'kindle',
+    storeProductId: 'B0ABC',
+    userBookCreatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function setupAuth() {
+  vi.mocked(createClient).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any)
+}
+
+async function renderPage(
+  params: Record<string, string> = { id: validSeriesId },
+  searchParams: Record<string, string> = {},
+) {
+  const element = await SeriesDetailPage({
+    params: Promise.resolve(params),
+    searchParams: Promise.resolve(searchParams),
+  })
+  render(element)
+}
+
+describe('SeriesDetailPage', () => {
+  beforeEach(() => {
+    setupAuth()
+    notFoundMock.mockClear()
+    redirectMock.mockClear()
+  })
+
+  it('正常系: シリーズ名・著者・巻数 + 巻ギャラリーを描画する', async () => {
+    const detail: SeriesDetail = {
+      series: { id: validSeriesId, title: 'ワンピース', author: '尾田栄一郎' },
+      volumes: [
+        makeVolume({ id: 'b1', userBookId: 'ub1', volumeNumber: 1 }),
+        makeVolume({ id: 'b2', userBookId: 'ub2', volumeNumber: 2 }),
+      ],
+    }
+    vi.mocked(getSeriesDetail).mockResolvedValue(detail)
+
+    await renderPage()
+
+    expect(screen.getByRole('heading', { name: 'ワンピース' })).toBeInTheDocument()
+    expect(screen.getByText(/尾田栄一郎.*2 巻所持/)).toBeInTheDocument()
+    expect(screen.getByText('ワンピース (1巻)')).toBeInTheDocument()
+    expect(screen.getByText('ワンピース (2巻)')).toBeInTheDocument()
+  })
+
+  it('Breadcrumb の「本棚」リンクは searchParams.q を保持する', async () => {
+    vi.mocked(getSeriesDetail).mockResolvedValue({
+      series: { id: validSeriesId, title: 'ワンピース', author: '尾田' },
+      volumes: [makeVolume()],
+    })
+
+    await renderPage({ id: validSeriesId }, { q: 'ワンピ' })
+
+    const link = screen.getByRole('link', { name: '本棚' })
+    expect(link.getAttribute('href')).toBe('/bookshelf?q=' + encodeURIComponent('ワンピ'))
+  })
+
+  it('searchParams.q が無い場合は /bookshelf に戻る', async () => {
+    vi.mocked(getSeriesDetail).mockResolvedValue({
+      series: { id: validSeriesId, title: 'ワンピース', author: '尾田' },
+      volumes: [makeVolume()],
+    })
+
+    await renderPage()
+
+    const link = screen.getByRole('link', { name: '本棚' })
+    expect(link.getAttribute('href')).toBe('/bookshelf')
+  })
+
+  it('UUID 形式でない id は notFound() を呼ぶ', async () => {
+    await expect(renderPage({ id: 'not-a-uuid' })).rejects.toThrow('NEXT_NOT_FOUND')
+    expect(notFoundMock).toHaveBeenCalled()
+    expect(getSeriesDetail).not.toHaveBeenCalled()
+  })
+
+  it('getSeriesDetail が null を返した場合 notFound() を呼ぶ (他ユーザーの series / 存在しない)', async () => {
+    vi.mocked(getSeriesDetail).mockResolvedValue(null)
+
+    await expect(renderPage()).rejects.toThrow('NEXT_NOT_FOUND')
+    expect(notFoundMock).toHaveBeenCalled()
+  })
+
+  it('未ログインの場合 redirect("/login") を呼ぶ', async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(renderPage()).rejects.toThrow('NEXT_REDIRECT')
+    expect(redirectMock).toHaveBeenCalled()
+  })
+
+  it('getSeriesDetail には auth user.id と parsed seriesId を渡す', async () => {
+    vi.mocked(getSeriesDetail).mockResolvedValue({
+      series: { id: validSeriesId, title: 'ワンピース', author: '尾田' },
+      volumes: [makeVolume()],
+    })
+
+    await renderPage()
+
+    expect(getSeriesDetail).toHaveBeenCalledWith(expect.anything(), 'user-123', validSeriesId)
+  })
+})

--- a/apps/web/app/(protected)/bookshelf/series/[id]/error.tsx
+++ b/apps/web/app/(protected)/bookshelf/series/[id]/error.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface SeriesDetailErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function SeriesDetailError({ error, reset }: SeriesDetailErrorProps) {
+  useEffect(() => {
+    console.error('[SeriesDetailError]', { digest: error.digest })
+  }, [error])
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col items-center justify-center px-4 py-16 text-center">
+      <h1 className="text-2xl font-bold">シリーズの読み込みに失敗しました</h1>
+      <p className="mt-4 text-sm text-muted-foreground">
+        一時的なエラーが発生した可能性があります。少し待ってから再試行してください。
+      </p>
+      {error.digest && (
+        <p className="mt-2 font-mono text-xs text-muted-foreground">エラー ID: {error.digest}</p>
+      )}
+      <Button onClick={reset} className="mt-6">
+        再試行
+      </Button>
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/bookshelf/series/[id]/loading.tsx
+++ b/apps/web/app/(protected)/bookshelf/series/[id]/loading.tsx
@@ -1,0 +1,19 @@
+export default function SeriesDetailLoading() {
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-8" aria-busy="true">
+      <div className="mb-4 h-4 w-32 animate-pulse rounded bg-muted" />
+      <div className="mb-6 space-y-2">
+        <div className="h-7 w-64 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+      </div>
+      <ul
+        aria-label="読み込み中"
+        className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+      >
+        {Array.from({ length: 12 }).map((_, i) => (
+          <li key={i} className="aspect-[2/3] animate-pulse rounded bg-muted" />
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/apps/web/app/(protected)/bookshelf/series/[id]/page.tsx
+++ b/apps/web/app/(protected)/bookshelf/series/[id]/page.tsx
@@ -4,6 +4,7 @@ import { seriesIdSchema } from '@bookhub/shared'
 import { createClient } from '@/lib/supabase/server'
 import { getSeriesDetail } from '@/lib/books/get-series-detail'
 import { BookGallery } from '@/features/bookshelf/book-gallery'
+import { EmptyState } from '@/features/bookshelf/empty-state'
 
 // 統一して force-dynamic (本棚と同方針: 拡張機能のスクレイプ後に最新データが見える要件)
 export const dynamic = 'force-dynamic'
@@ -49,7 +50,9 @@ export default async function SeriesDetailPage({ params, searchParams }: SeriesD
           {detail.series.author} · {detail.volumes.length} 巻所持
         </p>
       </header>
-      <BookGallery books={detail.volumes} />
+      {/* getSeriesDetail が 0 件で null → notFound() 済のため通常 volumes は空にならないが、
+          TOCTOU (チェック後に最後の巻が削除された等) の保険として emptyFallback を渡す。 */}
+      <BookGallery books={detail.volumes} emptyFallback={<EmptyState variant="empty" />} />
     </main>
   )
 }

--- a/apps/web/app/(protected)/bookshelf/series/[id]/page.tsx
+++ b/apps/web/app/(protected)/bookshelf/series/[id]/page.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+import { seriesIdSchema } from '@bookhub/shared'
+import { createClient } from '@/lib/supabase/server'
+import { getSeriesDetail } from '@/lib/books/get-series-detail'
+import { BookGallery } from '@/features/bookshelf/book-gallery'
+
+// 統一して force-dynamic (本棚と同方針: 拡張機能のスクレイプ後に最新データが見える要件)
+export const dynamic = 'force-dynamic'
+
+const MAX_QUERY_LENGTH = 200
+
+interface SeriesDetailPageProps {
+  params: Promise<{ id: string }>
+  // /bookshelf?q=... から遷移してきた場合に q を保持して戻れるようにする
+  searchParams: Promise<{ q?: string }>
+}
+
+export default async function SeriesDetailPage({ params, searchParams }: SeriesDetailPageProps) {
+  const { id: rawId } = await params
+  const parsed = seriesIdSchema.safeParse(rawId)
+  if (!parsed.success) notFound()
+
+  const { q } = await searchParams
+  const trimmedQ = (q?.trim() ?? '').slice(0, MAX_QUERY_LENGTH)
+  const backHref = trimmedQ ? `/bookshelf?q=${encodeURIComponent(trimmedQ)}` : '/bookshelf'
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const detail = await getSeriesDetail(supabase, user.id, parsed.data)
+  if (!detail) notFound()
+
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-8">
+      <nav className="mb-4 text-sm text-muted-foreground" aria-label="パンくず">
+        <Link href={backHref} className="hover:underline">
+          本棚
+        </Link>
+        <span className="mx-1">/</span>
+        <span aria-current="page">{detail.series.title}</span>
+      </nav>
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold">{detail.series.title}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {detail.series.author} · {detail.volumes.length} 巻所持
+        </p>
+      </header>
+      <BookGallery books={detail.volumes} />
+    </main>
+  )
+}

--- a/apps/web/features/bookshelf/__tests__/book-gallery.test.tsx
+++ b/apps/web/features/bookshelf/__tests__/book-gallery.test.tsx
@@ -34,24 +34,24 @@ describe('BookGallery', () => {
         title: '本B',
       }),
     ]
-    render(<BookGallery books={books} isSearching={false} />)
+    render(<BookGallery books={books} />)
     expect(screen.getByText(/本A/)).toBeInTheDocument()
     expect(screen.getByText(/本B/)).toBeInTheDocument()
   })
 
-  it('books 空配列 & isSearching=false のとき empty state を表示する', () => {
-    render(<BookGallery books={[]} isSearching={false} />)
-    expect(screen.getByText('蔵書がまだありません')).toBeInTheDocument()
+  it('books 空配列で emptyFallback が渡された場合はそれを描画する', () => {
+    render(<BookGallery books={[]} emptyFallback={<p>該当なし</p>} />)
+    expect(screen.getByText('該当なし')).toBeInTheDocument()
   })
 
-  it('books 空配列 & isSearching=true のとき no-results を表示する', () => {
-    render(<BookGallery books={[]} isSearching={true} />)
-    expect(screen.getByText('検索結果がありません')).toBeInTheDocument()
+  it('books 空配列で emptyFallback が無い場合は何も描画しない', () => {
+    const { container } = render(<BookGallery books={[]} />)
+    expect(container.textContent).toBe('')
   })
 
   it('books があるとき grid レイアウトの ul を描画する', () => {
     const books = [makeBook()]
-    render(<BookGallery books={books} isSearching={false} />)
+    render(<BookGallery books={books} />)
     const list = screen.getByRole('list', { name: /蔵書一覧/ })
     expect(list.className).toContain('grid')
   })

--- a/apps/web/features/bookshelf/__tests__/series-card.test.tsx
+++ b/apps/web/features/bookshelf/__tests__/series-card.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import type { UserSeries } from '@/lib/books/get-user-series'
+import { SeriesCard } from '../series-card'
+
+const baseSeries: UserSeries = {
+  seriesId: '11111111-1111-1111-1111-111111111111',
+  title: 'ワンピース',
+  author: '尾田栄一郎',
+  volumeCount: 105,
+  coverThumbnailUrl: 'https://m.media-amazon.com/images/I/abc.jpg',
+  stores: ['kindle'],
+  lastAddedAt: '2024-01-01T00:00:00.000Z',
+}
+
+describe('SeriesCard', () => {
+  it('シリーズタイトルと著者を表示する', () => {
+    render(<SeriesCard series={baseSeries} />)
+    expect(screen.getByText('ワンピース')).toBeInTheDocument()
+    expect(screen.getByText('尾田栄一郎')).toBeInTheDocument()
+  })
+
+  it('巻数バッジを「N 巻所持」で表示する (全 N 巻と誤解させない)', () => {
+    render(<SeriesCard series={baseSeries} />)
+    expect(screen.getByText('105 巻所持')).toBeInTheDocument()
+  })
+
+  it('/bookshelf/series/[id] への内部 Link を生成する', () => {
+    render(<SeriesCard series={baseSeries} />)
+    const link = screen.getByRole('link', { name: /ワンピース の巻一覧を開く/ })
+    expect(link.getAttribute('href')).toBe('/bookshelf/series/11111111-1111-1111-1111-111111111111')
+  })
+
+  it('coverThumbnailUrl が null のとき "No Cover" プレースホルダを描画する', () => {
+    render(<SeriesCard series={{ ...baseSeries, coverThumbnailUrl: null }} />)
+    expect(screen.getByText('No Cover')).toBeInTheDocument()
+  })
+
+  it('coverThumbnailUrl があるとき img タグを描画する (Edge 用 plain img)', () => {
+    render(<SeriesCard series={baseSeries} />)
+    const img = screen.getByAltText(/ワンピース の書影/) as HTMLImageElement
+    expect(img.tagName).toBe('IMG')
+    expect(img.src).toBe('https://m.media-amazon.com/images/I/abc.jpg')
+  })
+
+  it('複数ストア所有時は StoreBadge を複数描画する', () => {
+    render(<SeriesCard series={{ ...baseSeries, stores: ['kindle', 'dmm'] }} />)
+    const badges = screen.getAllByLabelText(/購入ストア:/)
+    expect(badges).toHaveLength(2)
+  })
+})

--- a/apps/web/features/bookshelf/__tests__/series-gallery.test.tsx
+++ b/apps/web/features/bookshelf/__tests__/series-gallery.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import type { UserSeries } from '@/lib/books/get-user-series'
+import { SeriesGallery } from '../series-gallery'
+
+function makeSeries(overrides: Partial<UserSeries> = {}): UserSeries {
+  return {
+    seriesId: '11111111-1111-1111-1111-111111111111',
+    title: 'シリーズ',
+    author: '著者',
+    volumeCount: 10,
+    coverThumbnailUrl: null,
+    stores: ['kindle'],
+    lastAddedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('SeriesGallery', () => {
+  it('渡されたシリーズを全て描画する', () => {
+    const series = [
+      makeSeries({ seriesId: 's1', title: 'シリーズA' }),
+      makeSeries({ seriesId: 's2', title: 'シリーズB' }),
+    ]
+    render(<SeriesGallery series={series} />)
+    expect(screen.getByText('シリーズA')).toBeInTheDocument()
+    expect(screen.getByText('シリーズB')).toBeInTheDocument()
+  })
+
+  it('series 空配列で emptyFallback が渡された場合はそれを描画する', () => {
+    render(<SeriesGallery series={[]} emptyFallback={<p>該当なし</p>} />)
+    expect(screen.getByText('該当なし')).toBeInTheDocument()
+  })
+
+  it('series 空配列で emptyFallback が無い場合は何も描画しない', () => {
+    const { container } = render(<SeriesGallery series={[]} />)
+    expect(container.textContent).toBe('')
+  })
+
+  it('series があるとき grid レイアウトの ul を描画する', () => {
+    render(<SeriesGallery series={[makeSeries()]} />)
+    const list = screen.getByRole('list', { name: /シリーズ一覧/ })
+    expect(list.className).toContain('grid')
+  })
+})

--- a/apps/web/features/bookshelf/book-gallery.tsx
+++ b/apps/web/features/bookshelf/book-gallery.tsx
@@ -1,15 +1,20 @@
+import type { ReactNode } from 'react'
 import type { BookWithStore } from '@bookhub/shared'
 import { BookCard } from './book-card'
-import { EmptyState } from './empty-state'
 
 interface BookGalleryProps {
   books: BookWithStore[]
-  isSearching: boolean
+  /**
+   * books が 0 件のときに表示する fallback。省略時は何も描画しない。
+   * 「蔵書 0 件」「検索結果 0 件」など empty 時の意味は呼出側ごとに違うため、
+   * EmptyState の variant 判定を内部に持たず外部に委ねる設計。
+   */
+  emptyFallback?: ReactNode
 }
 
-export function BookGallery({ books, isSearching }: BookGalleryProps) {
+export function BookGallery({ books, emptyFallback }: BookGalleryProps) {
   if (books.length === 0) {
-    return <EmptyState variant={isSearching ? 'no-results' : 'empty'} />
+    return <>{emptyFallback ?? null}</>
   }
 
   return (

--- a/apps/web/features/bookshelf/series-card.tsx
+++ b/apps/web/features/bookshelf/series-card.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+import type { UserSeries } from '@/lib/books/get-user-series'
+import { Card } from '@/components/ui/card'
+import { StoreBadge } from './store-badge'
+
+interface SeriesCardProps {
+  series: UserSeries
+}
+
+export function SeriesCard({ series }: SeriesCardProps) {
+  return (
+    <Link
+      href={`/bookshelf/series/${series.seriesId}`}
+      aria-label={`${series.title} の巻一覧を開く`}
+      className="block rounded-lg transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <Card className="overflow-hidden">
+        <div className="relative aspect-[2/3] bg-muted">
+          {series.coverThumbnailUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element -- Cloudflare Pages Edge では next/image 最適化が無効化されるため plain <img> を使用
+            <img
+              src={series.coverThumbnailUrl}
+              alt={`${series.title} の書影`}
+              loading="lazy"
+              className="absolute inset-0 h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              No Cover
+            </div>
+          )}
+          <div className="absolute right-2 top-2 flex flex-wrap gap-1">
+            {series.stores.map((store) => (
+              <StoreBadge key={store} store={store} />
+            ))}
+          </div>
+          <span
+            className="absolute bottom-2 left-2 rounded-full bg-foreground/80 px-2 py-0.5 text-xs font-medium text-background shadow-sm"
+            aria-label={`${series.volumeCount} 巻所持`}
+          >
+            {series.volumeCount} 巻所持
+          </span>
+        </div>
+        <div className="p-3">
+          <p className="line-clamp-2 text-sm font-medium" title={series.title}>
+            {series.title}
+          </p>
+          <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">{series.author}</p>
+        </div>
+      </Card>
+    </Link>
+  )
+}

--- a/apps/web/features/bookshelf/series-gallery.tsx
+++ b/apps/web/features/bookshelf/series-gallery.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+import type { UserSeries } from '@/lib/books/get-user-series'
+import { SeriesCard } from './series-card'
+
+interface SeriesGalleryProps {
+  series: UserSeries[]
+  /**
+   * series が 0 件のときに表示する fallback。省略時は何も描画しない。
+   */
+  emptyFallback?: ReactNode
+}
+
+export function SeriesGallery({ series, emptyFallback }: SeriesGalleryProps) {
+  if (series.length === 0) {
+    return <>{emptyFallback ?? null}</>
+  }
+
+  return (
+    <ul
+      aria-label="シリーズ一覧"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+    >
+      {series.map((s) => (
+        <li key={s.seriesId}>
+          <SeriesCard series={s} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/lib/books/__tests__/get-series-detail.test.ts
+++ b/apps/web/lib/books/__tests__/get-series-detail.test.ts
@@ -1,0 +1,135 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getSeriesDetail } from '../get-series-detail'
+
+// --- Mock helpers ---
+
+function createMockSupabase(result: {
+  data: Record<string, unknown>[] | null
+  error: { message: string } | null
+}) {
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    then: undefined as unknown,
+  }
+  Object.defineProperty(builder, 'then', {
+    value: (resolve: (v: unknown) => void) => {
+      resolve(result)
+      return Promise.resolve(result)
+    },
+  })
+  return {
+    from: vi.fn().mockReturnValue(builder),
+    _builder: builder,
+  } as unknown as SupabaseClient & { _builder: typeof builder }
+}
+
+const userId = 'user-uuid-123'
+const seriesId = '11111111-1111-1111-1111-111111111111'
+
+const mockRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'ub-1',
+  store: 'kindle',
+  created_at: '2026-04-19T08:19:21Z',
+  books: {
+    id: 'book-1',
+    series_id: seriesId,
+    volume_number: 1,
+    thumbnail_url: 'https://example.com/op-1.jpg',
+    isbn: '9784088xxx',
+    published_at: '2024-01-01',
+    is_adult: false,
+    store_product_id: 'B0ABC1',
+    created_at: '2024-01-01T00:00:00Z',
+    series: {
+      id: seriesId,
+      title: 'ワンピース',
+      author: '尾田栄一郎',
+    },
+    ...overrides,
+  },
+})
+
+// --- Tests ---
+
+describe('getSeriesDetail', () => {
+  it('正常系: series メタと volumes を返す', async () => {
+    const supabase = createMockSupabase({
+      data: [
+        mockRow(),
+        { ...mockRow(), id: 'ub-2', books: { ...mockRow().books, id: 'book-2', volume_number: 2 } },
+      ],
+      error: null,
+    })
+
+    const result = await getSeriesDetail(supabase, userId, seriesId)
+
+    expect(result).not.toBeNull()
+    expect(result!.series).toEqual({
+      id: seriesId,
+      title: 'ワンピース',
+      author: '尾田栄一郎',
+    })
+    expect(result!.volumes).toHaveLength(2)
+    expect(result!.volumes[0]).toMatchObject({
+      id: 'book-1',
+      title: 'ワンピース',
+      author: '尾田栄一郎',
+      volumeNumber: 1,
+      storeProductId: 'B0ABC1',
+      userBookId: 'ub-1',
+      store: 'kindle',
+    })
+  })
+
+  it('user_id と books.series_id で eq フィルタを掛ける (IDOR 防御)', async () => {
+    const supabase = createMockSupabase({ data: [mockRow()], error: null })
+
+    await getSeriesDetail(supabase, userId, seriesId)
+
+    expect(supabase.from).toHaveBeenCalledWith('user_books')
+    expect(supabase._builder.eq).toHaveBeenCalledWith('user_id', userId)
+    expect(supabase._builder.eq).toHaveBeenCalledWith('books.series_id', seriesId)
+  })
+
+  it('volume_number 昇順 (NULLS LAST) で order する', async () => {
+    const supabase = createMockSupabase({ data: [mockRow()], error: null })
+
+    await getSeriesDetail(supabase, userId, seriesId)
+
+    expect(supabase._builder.order).toHaveBeenCalledWith('volume_number', {
+      referencedTable: 'books',
+      nullsFirst: false,
+    })
+  })
+
+  it('0 件の場合は null を返す (存在しない / 他ユーザーの series)', async () => {
+    const supabase = createMockSupabase({ data: [], error: null })
+
+    const result = await getSeriesDetail(supabase, userId, seriesId)
+
+    expect(result).toBeNull()
+  })
+
+  it('store_product_id が NULL の行は storeProductId: null', async () => {
+    const row = mockRow()
+    row.books.store_product_id = null
+    const supabase = createMockSupabase({ data: [row], error: null })
+
+    const result = await getSeriesDetail(supabase, userId, seriesId)
+
+    expect(result!.volumes[0]?.storeProductId).toBeNull()
+  })
+
+  it('DB エラー時に throw する', async () => {
+    const supabase = createMockSupabase({
+      data: null,
+      error: { message: 'permission denied' },
+    })
+
+    await expect(getSeriesDetail(supabase, userId, seriesId)).rejects.toThrow(
+      /getSeriesDetail SELECT failed/,
+    )
+  })
+})

--- a/apps/web/lib/books/__tests__/get-series-detail.test.ts
+++ b/apps/web/lib/books/__tests__/get-series-detail.test.ts
@@ -93,15 +93,62 @@ describe('getSeriesDetail', () => {
     expect(supabase._builder.eq).toHaveBeenCalledWith('books.series_id', seriesId)
   })
 
-  it('volume_number 昇順 (NULLS LAST) で order する', async () => {
-    const supabase = createMockSupabase({ data: [mockRow()], error: null })
+  it('volumes は volume_number 昇順で返る (NULLS LAST、JS 側ソート)', async () => {
+    // PostgREST の order(referencedTable) は embedded sort で親行に効かないため、
+    // DB から順序保証なしで返ってきても JS 側で確実に並べる。
+    const v3 = mockRow()
+    v3.books.id = 'book-3'
+    v3.books.volume_number = 3
+    const v1 = {
+      ...mockRow(),
+      id: 'ub-1',
+      books: { ...mockRow().books, id: 'book-1', volume_number: 1 },
+    }
+    const vNull = {
+      ...mockRow(),
+      id: 'ub-null',
+      books: { ...mockRow().books, id: 'book-null', volume_number: null },
+    }
+    const v2 = {
+      ...mockRow(),
+      id: 'ub-2',
+      books: { ...mockRow().books, id: 'book-2', volume_number: 2 },
+    }
 
-    await getSeriesDetail(supabase, userId, seriesId)
+    // DB からは降順や混在で返ったとする
+    const supabase = createMockSupabase({ data: [v3, vNull, v1, v2], error: null })
 
-    expect(supabase._builder.order).toHaveBeenCalledWith('volume_number', {
-      referencedTable: 'books',
-      nullsFirst: false,
-    })
+    const result = await getSeriesDetail(supabase, userId, seriesId)
+
+    expect(result!.volumes.map((v) => v.volumeNumber)).toEqual([1, 2, 3, null])
+  })
+
+  it('同 volume_number は created_at で安定ソートされる', async () => {
+    const a = {
+      ...mockRow(),
+      id: 'ub-a',
+      books: {
+        ...mockRow().books,
+        id: 'book-a',
+        volume_number: 1,
+        created_at: '2024-01-02T00:00:00Z',
+      },
+    }
+    const b = {
+      ...mockRow(),
+      id: 'ub-b',
+      books: {
+        ...mockRow().books,
+        id: 'book-b',
+        volume_number: 1,
+        created_at: '2024-01-01T00:00:00Z',
+      },
+    }
+    const supabase = createMockSupabase({ data: [a, b], error: null })
+
+    const result = await getSeriesDetail(supabase, userId, seriesId)
+
+    expect(result!.volumes.map((v) => v.userBookId)).toEqual(['ub-b', 'ub-a'])
   })
 
   it('0 件の場合は null を返す (存在しない / 他ユーザーの series)', async () => {

--- a/apps/web/lib/books/__tests__/get-user-series.test.ts
+++ b/apps/web/lib/books/__tests__/get-user-series.test.ts
@@ -1,0 +1,161 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getUserSeries } from '../get-user-series'
+
+// --- Mock helpers ---
+
+function createMockSupabase(result: {
+  data: Record<string, unknown>[] | null
+  count: number | null
+  error: { message: string } | null
+}) {
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    then: undefined as unknown,
+  }
+  Object.defineProperty(builder, 'then', {
+    value: (resolve: (v: unknown) => void) => {
+      resolve(result)
+      return Promise.resolve(result)
+    },
+  })
+  return {
+    from: vi.fn().mockReturnValue(builder),
+    _builder: builder,
+  } as unknown as SupabaseClient & { _builder: typeof builder }
+}
+
+const userId = 'user-uuid-123'
+
+const mockRow = {
+  series_id: 'series-1',
+  title: 'ワンピース',
+  author: '尾田栄一郎',
+  volume_count: 105,
+  cover_thumbnail_url: 'https://example.com/op-1.jpg',
+  stores: ['kindle'],
+  last_added_at: '2026-04-19T08:19:21.483347Z',
+}
+
+// --- Tests ---
+
+describe('getUserSeries', () => {
+  it('view の結果を camelCase に変換する', async () => {
+    const supabase = createMockSupabase({ data: [mockRow], count: 1, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(result.series).toHaveLength(1)
+    expect(result.series[0]).toEqual({
+      seriesId: 'series-1',
+      title: 'ワンピース',
+      author: '尾田栄一郎',
+      volumeCount: 105,
+      coverThumbnailUrl: 'https://example.com/op-1.jpg',
+      stores: ['kindle'],
+      lastAddedAt: '2026-04-19T08:19:21.483347Z',
+    })
+    expect(result.total).toBe(1)
+    expect(result.page).toBe(1)
+    expect(result.limit).toBe(20)
+  })
+
+  it('user_series_view から user_id eq でフィルタする (defense in depth)', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(supabase.from).toHaveBeenCalledWith('user_series_view')
+    expect(supabase._builder.eq).toHaveBeenCalledWith('user_id', userId)
+  })
+
+  it('cover_thumbnail_url が NULL の行は coverThumbnailUrl: null にマッピングされる', async () => {
+    const nullRow = { ...mockRow, cover_thumbnail_url: null }
+    const supabase = createMockSupabase({ data: [nullRow], count: 1, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(result.series[0]?.coverThumbnailUrl).toBeNull()
+  })
+
+  it('複数ストアの stores 配列が保持される', async () => {
+    const multiStoreRow = { ...mockRow, stores: ['dmm', 'kindle'] }
+    const supabase = createMockSupabase({ data: [multiStoreRow], count: 1, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(result.series[0]?.stores).toEqual(['dmm', 'kindle'])
+  })
+
+  it('結果が空の場合、空配列を返す', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(result.series).toEqual([])
+    expect(result.total).toBe(0)
+  })
+
+  it('q パラメータがある場合、or フィルタを呼ぶ', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    await getUserSeries(supabase, userId, { q: 'ワンピ', page: 1, limit: 20 })
+
+    expect(supabase._builder.or).toHaveBeenCalledTimes(1)
+    const orCall = supabase._builder.or.mock.calls[0]?.[0] as string
+    expect(orCall).toMatch(/title\.ilike\.".*ワンピ.*"/)
+    expect(orCall).toMatch(/author\.ilike\.".*ワンピ.*"/)
+  })
+
+  it('q が無い場合、or フィルタを呼ばない', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(supabase._builder.or).not.toHaveBeenCalled()
+  })
+
+  it('q に LIKE メタ文字や `,` が含まれてもエスケープされる', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    await getUserSeries(supabase, userId, { q: '50%,_off', page: 1, limit: 20 })
+
+    const orCall = supabase._builder.or.mock.calls[0]?.[0] as string
+    // `%` `_` は LIKE エスケープで `\%` `\_` 化され、PostgREST の文字列 quote のために
+    // さらに `\` が `\\` に二重化される。`,` は `"..."` 囲みで literal 化 (or 区切りに誤解されない)。
+    expect(orCall).toContain('50\\\\%,\\\\_off')
+    expect(orCall).toMatch(/title\.ilike\."[^"]*"/)
+    expect(orCall).toMatch(/author\.ilike\."[^"]*"/)
+  })
+
+  it('page/limit に応じて range が正しい offset で呼ばれる', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    await getUserSeries(supabase, userId, { page: 3, limit: 10 })
+
+    expect(supabase._builder.range).toHaveBeenCalledWith(20, 29)
+  })
+
+  it('title 昇順でソートする', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(supabase._builder.order).toHaveBeenCalledWith('title')
+  })
+
+  it('DB エラー時に throw する', async () => {
+    const supabase = createMockSupabase({
+      data: null,
+      count: null,
+      error: { message: 'permission denied' },
+    })
+
+    await expect(getUserSeries(supabase, userId, { page: 1, limit: 20 })).rejects.toThrow(
+      /user_series_view SELECT failed/,
+    )
+  })
+})

--- a/apps/web/lib/books/__tests__/get-user-series.test.ts
+++ b/apps/web/lib/books/__tests__/get-user-series.test.ts
@@ -139,12 +139,49 @@ describe('getUserSeries', () => {
     expect(supabase._builder.range).toHaveBeenCalledWith(20, 29)
   })
 
-  it('title 昇順でソートする', async () => {
+  it('title 昇順 + series_id tie-breaker でソートする (ページング安定化)', async () => {
     const supabase = createMockSupabase({ data: [], count: 0, error: null })
 
     await getUserSeries(supabase, userId, { page: 1, limit: 20 })
 
-    expect(supabase._builder.order).toHaveBeenCalledWith('title')
+    expect(supabase._builder.order).toHaveBeenNthCalledWith(1, 'title', { ascending: true })
+    expect(supabase._builder.order).toHaveBeenNthCalledWith(2, 'series_id', { ascending: true })
+  })
+
+  it('page=0 は 1 にコエルスして range は negative にならない', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 0, limit: 20 })
+
+    expect(supabase._builder.range).toHaveBeenCalledWith(0, 19)
+    expect(result.page).toBe(1)
+  })
+
+  it('limit=0 は 1 にコエルスする', async () => {
+    const supabase = createMockSupabase({ data: [], count: 0, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 1, limit: 0 })
+
+    expect(supabase._builder.range).toHaveBeenCalledWith(0, 0)
+    expect(result.limit).toBe(1)
+  })
+
+  it('stores に想定外の値が含まれる場合はフィルタで除外する', async () => {
+    const dirtyRow = { ...mockRow, stores: ['kindle', 'invalid_store', 'dmm'] }
+    const supabase = createMockSupabase({ data: [dirtyRow], count: 1, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(result.series[0]?.stores).toEqual(['kindle', 'dmm'])
+  })
+
+  it('stores が null/undefined の場合は空配列にフォールバックする', async () => {
+    const nullStoresRow = { ...mockRow, stores: null }
+    const supabase = createMockSupabase({ data: [nullStoresRow], count: 1, error: null })
+
+    const result = await getUserSeries(supabase, userId, { page: 1, limit: 20 })
+
+    expect(result.series[0]?.stores).toEqual([])
   })
 
   it('DB エラー時に throw する', async () => {

--- a/apps/web/lib/books/get-series-detail.ts
+++ b/apps/web/lib/books/get-series-detail.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { BookWithStore } from '@bookhub/shared'
+import type { BookWithStore, SeriesId } from '@bookhub/shared'
 
 export interface SeriesDetail {
   series: {
@@ -42,12 +42,15 @@ interface UserBookRow {
  * - 0 件なら null を返す。呼出側で `notFound()` を呼ぶ前提
  *   - 存在しない seriesId / 他ユーザーの series (= 自分は所持していない) は同じ「0 件」
  *     になり情報リーク (IDOR) を回避する
- * - 巻は `volume_number ASC NULLS LAST` でソート
+ * - 巻は `volume_number ASC NULLS LAST` でソート (取得後 JS 側で並べ替え)
+ *   - PostgREST の `.order(..., { referencedTable: 'books' })` は **embedded resource 内**の
+ *     ソートで、親 (user_books) 行のソート順には影響しない仕様。inner join であっても同様。
+ *     1-query で取得した行をアプリ層で安定ソートする方が確実かつシンプル。
  */
 export async function getSeriesDetail(
   supabase: SupabaseClient,
   userId: string,
-  seriesId: string,
+  seriesId: SeriesId,
 ): Promise<SeriesDetail | null> {
   const { data, error } = await supabase
     .from('user_books')
@@ -56,7 +59,6 @@ export async function getSeriesDetail(
     )
     .eq('user_id', userId)
     .eq('books.series_id', seriesId)
-    .order('volume_number', { referencedTable: 'books', nullsFirst: false })
 
   if (error) throw new Error(`getSeriesDetail SELECT failed: ${error.message}`)
 
@@ -75,6 +77,16 @@ export async function getSeriesDetail(
       )
     }
   }
+
+  // volume_number ASC NULLS LAST。同 volume_number は created_at で安定化。
+  rows.sort((a, b) => {
+    const va = a.books.volume_number
+    const vb = b.books.volume_number
+    if (va === vb) return a.books.created_at.localeCompare(b.books.created_at)
+    if (va === null) return 1
+    if (vb === null) return -1
+    return va - vb
+  })
 
   const volumes: BookWithStore[] = rows.map((row) => ({
     id: row.books.id,

--- a/apps/web/lib/books/get-series-detail.ts
+++ b/apps/web/lib/books/get-series-detail.ts
@@ -1,0 +1,85 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { BookWithStore } from '@bookhub/shared'
+
+export interface SeriesDetail {
+  series: {
+    id: string
+    title: string
+    author: string
+  }
+  volumes: BookWithStore[]
+}
+
+interface UserBookRow {
+  id: string
+  store: string
+  created_at: string
+  books: {
+    id: string
+    series_id: string
+    volume_number: number | null
+    thumbnail_url: string | null
+    isbn: string | null
+    published_at: string | null
+    is_adult: boolean
+    store_product_id: string | null
+    created_at: string
+    series: {
+      id: string
+      title: string
+      author: string
+    }
+  }
+}
+
+/**
+ * 指定 series の所持巻一覧 + シリーズメタを 1 query で取得する。
+ *
+ * - user_books → books → series を inner join で固定し、`user_id eq` + `series_id eq` でフィルタ
+ * - 0 件なら null を返す。呼出側で `notFound()` を呼ぶ前提
+ *   - 存在しない seriesId / 他ユーザーの series (= 自分は所持していない) は同じ「0 件」
+ *     になり情報リーク (IDOR) を回避する
+ * - 巻は `volume_number ASC NULLS LAST` でソート
+ */
+export async function getSeriesDetail(
+  supabase: SupabaseClient,
+  userId: string,
+  seriesId: string,
+): Promise<SeriesDetail | null> {
+  const { data, error } = await supabase
+    .from('user_books')
+    .select(
+      'id, store, created_at, books!inner(id, series_id, volume_number, thumbnail_url, isbn, published_at, is_adult, store_product_id, created_at, series!inner(id, title, author))',
+    )
+    .eq('user_id', userId)
+    .eq('books.series_id', seriesId)
+    .order('volume_number', { referencedTable: 'books', nullsFirst: false })
+
+  if (error) throw new Error(`getSeriesDetail SELECT failed: ${error.message}`)
+
+  const rows = (data ?? []) as unknown as UserBookRow[]
+  if (rows.length === 0) return null
+
+  const first = rows[0]!.books.series
+
+  const volumes: BookWithStore[] = rows.map((row) => ({
+    id: row.books.id,
+    title: row.books.series.title,
+    author: row.books.series.author,
+    volumeNumber: row.books.volume_number,
+    thumbnailUrl: row.books.thumbnail_url,
+    isbn: row.books.isbn,
+    publishedAt: row.books.published_at,
+    isAdult: row.books.is_adult,
+    createdAt: row.books.created_at,
+    userBookId: row.id,
+    store: row.store as BookWithStore['store'],
+    storeProductId: row.books.store_product_id,
+    userBookCreatedAt: row.created_at,
+  }))
+
+  return {
+    series: { id: first.id, title: first.title, author: first.author },
+    volumes,
+  }
+}

--- a/apps/web/lib/books/get-series-detail.ts
+++ b/apps/web/lib/books/get-series-detail.ts
@@ -36,6 +36,9 @@ interface UserBookRow {
  * 指定 series の所持巻一覧 + シリーズメタを 1 query で取得する。
  *
  * - user_books → books → series を inner join で固定し、`user_id eq` + `series_id eq` でフィルタ
+ *   - `.eq('books.series_id', seriesId)` は PostgREST の embedded resource filter として
+ *     SQL 側 WHERE 句に変換され、`books!inner` と組み合わさって inner join filter になる
+ *     (get-user-books.ts の `books.is_adult` フィルタと同パターン・同セマンティクス)
  * - 0 件なら null を返す。呼出側で `notFound()` を呼ぶ前提
  *   - 存在しない seriesId / 他ユーザーの series (= 自分は所持していない) は同じ「0 件」
  *     になり情報リーク (IDOR) を回避する
@@ -60,7 +63,18 @@ export async function getSeriesDetail(
   const rows = (data ?? []) as unknown as UserBookRow[]
   if (rows.length === 0) return null
 
+  // `.eq('books.series_id', seriesId)` で絞っているため全行が同一シリーズを指す前提。
+  // 開発環境では誰かが series_id フィルタを外した時に sirent fail しないよう assertion で守る。
   const first = rows[0]!.books.series
+  if (process.env.NODE_ENV !== 'production') {
+    const inconsistent = rows.find((r) => r.books.series.id !== first.id)
+    if (inconsistent) {
+      throw new Error(
+        `getSeriesDetail invariant violated: rows contain mixed series_ids (${first.id} vs ${inconsistent.books.series.id}). ` +
+          'Did you remove the books.series_id filter?',
+      )
+    }
+  }
 
   const volumes: BookWithStore[] = rows.map((row) => ({
     id: row.books.id,

--- a/apps/web/lib/books/get-user-books.ts
+++ b/apps/web/lib/books/get-user-books.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { GetBooksQuery, GetBooksResponse, BookWithStore } from '@bookhub/shared'
+import { buildQuotedIlikePattern } from './postgrest-helpers'
 
 interface UserBookWithBooks {
   id: string
@@ -19,23 +20,6 @@ interface UserBookWithBooks {
       author: string
     }
   }
-}
-
-// ilike 用の値を PostgREST `.or()` に安全に埋め込むための 2 段エスケープ。
-//
-//   1. LIKE メタ文字 (`\`, `%`, `_`) を `\` でエスケープする。`\` を最初にするのは、
-//      後続の `\%` / `\_` 置換で生成した `\` を二重エスケープしないため。
-//   2. PostgREST のフィルタ値として `.or()` に渡すため、値を `"..."` で囲む。
-//      PostgREST の `"..."` 構文では `,` `.` `(` `)` `:` 等の構造的メタ文字が
-//      literal 扱いになるが、内側の `"` と `\` は `\` でエスケープが必要。
-//
-// これにより、ユーザー検索クエリに `,` や `(` 等が含まれても `.or()` の
-// フィルタ区切りが誤解釈されない。
-function buildQuotedIlikePattern(value: string): string {
-  const likeEscaped = value.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
-  const pattern = `%${likeEscaped}%`
-  const postgrestEscaped = pattern.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-  return `"${postgrestEscaped}"`
 }
 
 export async function getUserBooks(

--- a/apps/web/lib/books/get-user-series.ts
+++ b/apps/web/lib/books/get-user-series.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Store } from '@bookhub/shared'
+import { buildQuotedIlikePattern } from './postgrest-helpers'
+
+export interface UserSeries {
+  seriesId: string
+  title: string
+  author: string
+  volumeCount: number
+  coverThumbnailUrl: string | null
+  stores: Store[]
+  lastAddedAt: string
+}
+
+export interface GetUserSeriesQuery {
+  q?: string
+  page: number
+  limit: number
+}
+
+export interface GetUserSeriesResult {
+  series: UserSeries[]
+  total: number
+  page: number
+  limit: number
+}
+
+interface UserSeriesRow {
+  series_id: string
+  title: string
+  author: string
+  volume_count: number
+  cover_thumbnail_url: string | null
+  stores: string[]
+  last_added_at: string
+}
+
+export async function getUserSeries(
+  supabase: SupabaseClient,
+  userId: string,
+  query: GetUserSeriesQuery,
+): Promise<GetUserSeriesResult> {
+  let qb = supabase
+    .from('user_series_view')
+    .select('series_id, title, author, volume_count, cover_thumbnail_url, stores, last_added_at', {
+      count: 'exact',
+    })
+    // RLS と併せた defense in depth: view は security_invoker で内部 RLS が
+    // 効くが、明示的な user_id フィルタを残して二重防御する。
+    .eq('user_id', userId)
+
+  if (query.q) {
+    const pattern = buildQuotedIlikePattern(query.q)
+    qb = qb.or(`title.ilike.${pattern},author.ilike.${pattern}`)
+  }
+
+  const offset = (query.page - 1) * query.limit
+  qb = qb.order('title').range(offset, offset + query.limit - 1)
+
+  const { data, count, error } = await qb
+
+  if (error) throw new Error(`user_series_view SELECT failed: ${error.message}`)
+
+  const rows = (data ?? []) as unknown as UserSeriesRow[]
+
+  const series: UserSeries[] = rows.map((row) => ({
+    seriesId: row.series_id,
+    title: row.title,
+    author: row.author,
+    volumeCount: row.volume_count,
+    coverThumbnailUrl: row.cover_thumbnail_url,
+    stores: row.stores as Store[],
+    lastAddedAt: row.last_added_at,
+  }))
+
+  return {
+    series,
+    total: count ?? 0,
+    page: query.page,
+    limit: query.limit,
+  }
+}

--- a/apps/web/lib/books/get-user-series.ts
+++ b/apps/web/lib/books/get-user-series.ts
@@ -35,11 +35,19 @@ interface UserSeriesRow {
   last_added_at: string
 }
 
+const VALID_STORES: ReadonlySet<Store> = new Set(['kindle', 'dmm', 'other'])
+const isStore = (value: string): value is Store => VALID_STORES.has(value as Store)
+
 export async function getUserSeries(
   supabase: SupabaseClient,
   userId: string,
   query: GetUserSeriesQuery,
 ): Promise<GetUserSeriesResult> {
+  // page/limit は Server Component の固定値 (1, 100) や API zod schema を通った
+  // 値が渡る前提だが、不正値で range 引数が負になるのを防ぐ defensive guard。
+  const page = Math.max(1, Math.floor(query.page) || 1)
+  const limit = Math.max(1, Math.floor(query.limit) || 1)
+
   let qb = supabase
     .from('user_series_view')
     .select('series_id, title, author, volume_count, cover_thumbnail_url, stores, last_added_at', {
@@ -54,8 +62,13 @@ export async function getUserSeries(
     qb = qb.or(`title.ilike.${pattern},author.ilike.${pattern}`)
   }
 
-  const offset = (query.page - 1) * query.limit
-  qb = qb.order('title').range(offset, offset + query.limit - 1)
+  const offset = (page - 1) * limit
+  // 同タイトル複数シリーズがあるとページ跨ぎの重複/取りこぼしが起きうるため、
+  // 一意キー (series_id) を tie-breaker として第 2 ソートに加え、ページング安定性を担保。
+  qb = qb
+    .order('title', { ascending: true })
+    .order('series_id', { ascending: true })
+    .range(offset, offset + limit - 1)
 
   const { data, count, error } = await qb
 
@@ -69,14 +82,16 @@ export async function getUserSeries(
     author: row.author,
     volumeCount: row.volume_count,
     coverThumbnailUrl: row.cover_thumbnail_url,
-    stores: row.stores as Store[],
+    // DB 側 CHECK 制約 (`store IN ('kindle', 'dmm', 'other')`) で正規値しか入らない前提だが、
+    // 万一 view が想定外値を返しても enum に出ないよう runtime filter でセーフ化。
+    stores: (row.stores ?? []).filter(isStore),
     lastAddedAt: row.last_added_at,
   }))
 
   return {
     series,
     total: count ?? 0,
-    page: query.page,
-    limit: query.limit,
+    page,
+    limit,
   }
 }

--- a/apps/web/lib/books/postgrest-helpers.ts
+++ b/apps/web/lib/books/postgrest-helpers.ts
@@ -1,0 +1,16 @@
+// ilike 用の値を PostgREST `.or()` に安全に埋め込むための 2 段エスケープ。
+//
+//   1. LIKE メタ文字 (`\`, `%`, `_`) を `\` でエスケープする。`\` を最初にするのは、
+//      後続の `\%` / `\_` 置換で生成した `\` を二重エスケープしないため。
+//   2. PostgREST のフィルタ値として `.or()` に渡すため、値を `"..."` で囲む。
+//      PostgREST の `"..."` 構文では `,` `.` `(` `)` `:` 等の構造的メタ文字が
+//      literal 扱いになるが、内側の `"` と `\` は `\` でエスケープが必要。
+//
+// これにより、ユーザー検索クエリに `,` や `(` 等が含まれても `.or()` の
+// フィルタ区切りが誤解釈されない。
+export function buildQuotedIlikePattern(value: string): string {
+  const likeEscaped = value.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+  const pattern = `%${likeEscaped}%`
+  const postgrestEscaped = pattern.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return `"${postgrestEscaped}"`
+}

--- a/docs/specs/DB_SCHEMA.md
+++ b/docs/specs/DB_SCHEMA.md
@@ -89,7 +89,13 @@ CREATE TRIGGER on_auth_user_created
 
 ### インデックス
 
-`series_title_author_unique` (UNIQUE制約) が `(title, author)` B-tree 索引を兼ねるため追加インデックスなし。
+| インデックス                 | カラム                | 種別                 | 用途                                                               |
+| ---------------------------- | --------------------- | -------------------- | ------------------------------------------------------------------ |
+| `series_title_author_unique` | (title, author)       | UNIQUE B-tree (制約) | 同一シリーズ重複防止 + prefix 一致検索                             |
+| `idx_series_title_trgm`      | title (gin_trgm_ops)  | GIN (pg_trgm)        | `title ILIKE '%foo%'` の中間一致検索 (`/bookshelf` シリーズ検索用) |
+| `idx_series_author_trgm`     | author (gin_trgm_ops) | GIN (pg_trgm)        | `author ILIKE '%foo%'` の中間一致検索                              |
+
+**背景**: pg_trgm の GIN インデックスは ILIKE の中間一致 (`%foo%`) に対応するため、シリーズ件数が増加してもシリーズ検索のレイテンシを抑えられる。書き込みコストはやや増えるが、series の INSERT は scrape 時のみで低頻度のため許容。
 
 ### RLS ポリシー
 
@@ -211,6 +217,8 @@ CREATE TRIGGER user_books_updated_at
 
 ### 定義
 
+下記は要旨。`cover_thumbnail_url` と `stores` の correlated subquery 実装は省略しているため、完全な定義は migration ファイル `supabase/migrations/20260420000001_user_series_view.sql` を参照すること。
+
 ```sql
 CREATE OR REPLACE VIEW public.user_series_view
 WITH (security_invoker = on)
@@ -221,8 +229,8 @@ SELECT
   s.title,
   s.author,
   COUNT(DISTINCT b.id)::int AS volume_count,
-  ( /* 最小 volume_number で thumbnail_url が NOT NULL の最初の巻 */ ) AS cover_thumbnail_url,
-  ARRAY( /* DISTINCT + ORDER BY store でソート安定 */ ) AS stores,
+  ( /* 最小 volume_number で thumbnail_url が NOT NULL の最初の巻 — 詳細は migration 参照 */ ) AS cover_thumbnail_url,
+  ARRAY( /* DISTINCT + ORDER BY store でソート安定 — 詳細は migration 参照 */ ) AS stores,
   MAX(ub.created_at) AS last_added_at
 FROM public.user_books ub
 JOIN public.books   b ON b.id = ub.book_id
@@ -275,6 +283,7 @@ GRANT SELECT ON public.user_series_view TO authenticated;
 | `20260419000005` | `cleanup_post_parser_fix`      | ✓       | parser 修正後に流入した汚染 series 行を再正規化                      |
 | `20260419000006` | `fix_rpc_on_conflict_update`   | ✓       | `upsert_book_with_series` の series UPSERT を `DO NOTHING` に修正    |
 | `20260420000001` | `user_series_view`             | ✓       | `user_series_view` ビュー導入（シリーズ単位本棚の集約クエリ用）      |
+| `20260420000002` | `series_trgm_indexes`          | ✓       | `series.title` / `series.author` に pg_trgm GIN インデックス追加     |
 
 ---
 

--- a/docs/specs/DB_SCHEMA.md
+++ b/docs/specs/DB_SCHEMA.md
@@ -10,9 +10,10 @@ BookHub の Supabase PostgreSQL スキーマ定義。全テーブルは Row Leve
 2. [series](#series-シリーズマスタ)
 3. [books](#books-書籍マスタ)
 4. [user_books](#user_books-ユーザー所持情報)
-5. [Migration History](#migration-history)
-6. [Row Level Security (RLS)](#row-level-security)
-7. [Query Examples](#query-examples)
+5. [user_series_view](#user_series_viewシリーズ集約ビュー)
+6. [Migration History](#migration-history)
+7. [Row Level Security (RLS)](#row-level-security)
+8. [Query Examples](#query-examples)
 
 ---
 
@@ -200,6 +201,63 @@ CREATE TRIGGER user_books_updated_at
 
 ---
 
+## user_series_view（シリーズ集約ビュー）
+
+`/bookshelf` のシリーズ一覧表示用のビュー。`user_books → books → series` を JOIN し、ユーザー × シリーズ単位で集約する。
+
+### 背景
+
+シリーズ単位の本棚 UI（Issue #33）で「最小巻表紙 + 巻数バッジ + 所有ストア集合」を `count: 'exact'` でページング可能な形で取得するために導入。アプリ層 (JS) で集約する案も検討したが、行数上限による silently truncate のリスクがあるため view を採用。
+
+### 定義
+
+```sql
+CREATE OR REPLACE VIEW public.user_series_view
+WITH (security_invoker = on)
+AS
+SELECT
+  ub.user_id,
+  s.id AS series_id,
+  s.title,
+  s.author,
+  COUNT(DISTINCT b.id)::int AS volume_count,
+  ( /* 最小 volume_number で thumbnail_url が NOT NULL の最初の巻 */ ) AS cover_thumbnail_url,
+  ARRAY( /* DISTINCT + ORDER BY store でソート安定 */ ) AS stores,
+  MAX(ub.created_at) AS last_added_at
+FROM public.user_books ub
+JOIN public.books   b ON b.id = ub.book_id
+JOIN public.series  s ON s.id = b.series_id
+GROUP BY ub.user_id, s.id, s.title, s.author;
+
+GRANT SELECT ON public.user_series_view TO authenticated;
+```
+
+### カラム
+
+| カラム                | 型           | 説明                                                                                |
+| --------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `user_id`             | uuid         | 所有ユーザー (`user_books.user_id` 由来)                                            |
+| `series_id`           | uuid         | シリーズ ID (`series.id`)                                                           |
+| `title`               | text         | シリーズタイトル                                                                    |
+| `author`              | text         | シリーズ著者                                                                        |
+| `volume_count`        | int          | ユーザー所有の distinct book 数                                                     |
+| `cover_thumbnail_url` | text \| null | 最小 `volume_number` で `thumbnail_url IS NOT NULL` の巻のサムネイル。無ければ null |
+| `stores`              | text[]       | 所有 user_books の distinct ストア集合 (sort 済)                                    |
+| `last_added_at`       | timestamptz  | `MAX(user_books.created_at)`。最近追加順ソートのための予備                          |
+
+### セキュリティ
+
+- `WITH (security_invoker = on)` 指定により、view 経由 SELECT には呼出ユーザーの RLS が適用される
+- 内部の `user_books` テーブルが `auth.uid() = user_id` ポリシーを持つため、自分の行のみが集約に含まれる
+- アプリ層 (PostgREST) でも defense in depth として `.eq('user_id', userId)` を明示する規約
+
+### 用途
+
+- `apps/web/lib/books/get-user-series.ts` から `from('user_series_view').select(...)` で利用
+- ILIKE 検索 (`title.ilike` / `author.ilike`) は view 列に直接適用可能
+
+---
+
 ## Migration History
 
 | Version          | Name                           | Applied | 説明                                                                 |
@@ -214,6 +272,9 @@ CREATE TRIGGER user_books_updated_at
 | `20260419000002` | `upsert_book_with_series_rpc`  | ✓       | `upsert_book_with_series` RPC (series + books を atomic に登録)      |
 | `20260419000003` | `backfill_parser_fix`          | ✓       | parser 相当 SQL で既存 books を再解析、series 再バックフィル         |
 | `20260419000004` | `drop_books_title_author`      | ✓       | `books.title` / `books.author` を DROP (series 正規化完了)           |
+| `20260419000005` | `cleanup_post_parser_fix`      | ✓       | parser 修正後に流入した汚染 series 行を再正規化                      |
+| `20260419000006` | `fix_rpc_on_conflict_update`   | ✓       | `upsert_book_with_series` の series UPSERT を `DO NOTHING` に修正    |
+| `20260420000001` | `user_series_view`             | ✓       | `user_series_view` ビュー導入（シリーズ単位本棚の集約クエリ用）      |
 
 ---
 
@@ -252,6 +313,13 @@ CREATE TRIGGER user_books_updated_at
 │  - INSERT: auth.uid() = user_id   （自分のみ）              │
 │  - UPDATE: auth.uid() = user_id   （自分のみ）              │
 │  - DELETE: auth.uid() = user_id   （自分のみ）              │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                  user_series_view (VIEW)                     │
+│  - security_invoker = on                                     │
+│  - 内部の user_books の RLS が呼出ユーザーに対して効く        │
+│  - GRANT SELECT TO authenticated                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -292,6 +360,34 @@ JOIN series s ON s.id = b.series_id
 WHERE ub.user_id = $1
 GROUP BY s.id, s.title, s.author
 ORDER BY s.title;
+```
+
+### シリーズ単位本棚（`user_series_view` 経由・PostgREST から利用）
+
+`/bookshelf` (Issue #33) で `count: 'exact'` ページング + ILIKE 検索を 1 query で。
+
+```sql
+-- raw SQL 等価
+SELECT series_id, title, author, volume_count, cover_thumbnail_url, stores, last_added_at
+FROM public.user_series_view
+WHERE user_id = $1
+  AND (title ILIKE $2 OR author ILIKE $2)  -- $2 例: '%ワンピ%'
+ORDER BY title
+LIMIT $3 OFFSET $4;
+```
+
+PostgREST 経由:
+
+```ts
+supabase
+  .from('user_series_view')
+  .select('series_id, title, author, volume_count, cover_thumbnail_url, stores, last_added_at', {
+    count: 'exact',
+  })
+  .eq('user_id', userId)
+  .or(`title.ilike.${pattern},author.ilike.${pattern}`)
+  .order('title')
+  .range(offset, offset + limit - 1)
 ```
 
 ### 二度買い防止チェック

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -319,6 +319,13 @@ API が 401 を返した場合、Background Service Worker は `chrome.storage.l
 - **JS 集約 (LIMIT 5000)**: silently truncate のリスク。データ欠落を UI から検出できず、二度買い防止に致命的
 - **RPC `get_user_series(...)`**: 集約の write side atomicity が要らない読み取り専用ユースケースには tool mismatch。view の方が宣言的
 
+**運用注意点:**
+
+- **`series` への非公開列追加時のリスク**: 現在 `series` テーブルの RLS は `auth.role() = 'authenticated'` で全件 SELECT 可能。`user_series_view` は `user_books` 経由で自分の所持シリーズだけが集約に入るため、現状は他ユーザーのシリーズメタが漏洩しない。将来 `series` に「ユーザー間で共有しない列」(例: 個人メモ・所持メタ等) を追加する場合は、view 定義の見直し (列を view から外す or 別テーブルに分離) が必要になる
+- **集約コスト**: `cover_thumbnail_url` / `stores` は correlated subquery 2 本で取得しており、シリーズ件数 × 2 のオーバーヘッドが発生する。`books(series_id)` + `user_books(user_id, book_id)` の既存インデックスがあるため MVP スケール (1 ユーザー数百シリーズ) では問題ない。`EXPLAIN ANALYZE` で 100 件取得が ms オーダーで完了することを確認済 (適用直後の dev 環境で ~0.7ms)
+- **ILIKE 検索のインデックス**: `20260420000002_series_trgm_indexes.sql` で `series.title` / `series.author` に pg_trgm GIN インデックスを追加済。シリーズ件数が小さい段階では planner が seq scan を選ぶが、件数増加時に自動的に index scan に切り替わる
+- **`stores text[]` カラムと TS `Store[]` の同期**: view の `stores` は `user_books.store` (`CHECK (store IN ('kindle', 'dmm', 'other'))`) の DISTINCT 集約。アプリ層では `as Store[]` でキャストし `packages/shared` の `storeSchema = z.enum([...])` と整合させている。**ストア種別を追加する際は (1) DB CHECK 制約 (2) `storeSchema` の enum (3) `STORE_LABEL` / `STORE_VARIANT` の 3 箇所を同時に更新する必要がある**
+
 ### 6.3 SC ページの戻りリンクは searchParams を保持する
 
 **規約:** 詳細ページ (例: `/bookshelf/series/[id]`) の Breadcrumb / 戻りリンクは、遷移元の検索 state (`searchParams.q` など) を `?q=...` で復元できる形で組み立てる。

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -296,6 +296,47 @@ API が 401 を返した場合、Background Service Worker は `chrome.storage.l
 - **Supabase を SC から直接 query**: 検索・ソート・ページング等のクエリ構築ロジックが API ルートと重複する。
 - **専用の `fetch-user-books-for-ssr.ts` ラッパを新設**: 既存の `getUserBooks()` が既に SC から直接呼べる純粋関数なので抽象の水増し。
 
+### 6.2 シリーズ単位本棚の集約戦略 (ADR)
+
+**決定:** `/bookshelf` (シリーズ一覧) のデータ取得は、**`user_series_view` を経由した単一 PostgREST クエリ**で実装する。アプリ層 (JS) での集約は採用しない。
+
+**背景:**
+
+- Issue #33 で `/bookshelf` をシリーズ単位の二階層 UI に再構成した
+- 当初案 (PostgREST 1 query で `user_books → books → series` を取得 → JS で `series_id` 集約 + `LIMIT 5000` 安全弁) は、行数上限を超えたシリーズが silently truncate されるリスクがあり、二度買い防止というコア価値と直接衝突する
+- `count: 'exact'` でシリーズ単位の正確なページングが取れないことも問題
+
+**採用した設計:**
+
+- `supabase/migrations/20260420000001_user_series_view.sql` で `user_series_view` を `WITH (security_invoker = on)` で定義
+- 集約 (`volume_count`, `cover_thumbnail_url`, `stores`, `last_added_at`) は SQL 側で完結する
+- `apps/web/lib/books/get-user-series.ts` から `from('user_series_view').select(..., { count: 'exact' }).eq('user_id', userId)` で叩く
+- ILIKE 検索は view の `title` / `author` 列に直接かかる (ネスト `referencedTable` の workaround 不要)
+- RLS は内部の `user_books` テーブル (`auth.uid() = user_id`) が view 経由で自動適用される。アプリ層でも `.eq('user_id', userId)` を明示する規約 (defense in depth)
+
+**却下した代替案:**
+
+- **JS 集約 (LIMIT 5000)**: silently truncate のリスク。データ欠落を UI から検出できず、二度買い防止に致命的
+- **RPC `get_user_series(...)`**: 集約の write side atomicity が要らない読み取り専用ユースケースには tool mismatch。view の方が宣言的
+
+### 6.3 SC ページの戻りリンクは searchParams を保持する
+
+**規約:** 詳細ページ (例: `/bookshelf/series/[id]`) の Breadcrumb / 戻りリンクは、遷移元の検索 state (`searchParams.q` など) を `?q=...` で復元できる形で組み立てる。
+
+**理由:**
+
+- 検索で絞り込んだ結果から詳細ページに入り、戻った時に検索 state が消えると UX が劣化する
+- ブラウザの戻るボタンでも履歴復元はできるが、明示的なリンクで戻る挙動も同等であるべき
+
+**実装パターン:**
+
+```tsx
+const backHref = q ? `/bookshelf?q=${encodeURIComponent(q)}` : '/bookshelf'
+<Link href={backHref}>本棚</Link>
+```
+
+将来の他ページ (例: 巻詳細・ストア絞り込み復元) も同方針で揃える。
+
 ---
 
 ## 7. Cloudflare Pages Edge Runtime の制約

--- a/packages/shared/src/schemas/__tests__/books-api-schema.test.ts
+++ b/packages/shared/src/schemas/__tests__/books-api-schema.test.ts
@@ -1,5 +1,6 @@
 import {
   userBookIdSchema,
+  seriesIdSchema,
   registerBookSchema,
   updateUserBookSchema,
   getBooksQuerySchema,
@@ -53,6 +54,22 @@ describe('userBookIdSchema', () => {
     '無効な値 %j を拒否する',
     (value) => {
       expect(userBookIdSchema.safeParse(value).success).toBe(false)
+    },
+  )
+})
+
+// --- seriesIdSchema ---
+
+describe('seriesIdSchema', () => {
+  it('有効な UUID を受け入れる', () => {
+    const result = seriesIdSchema.safeParse('11111111-1111-1111-1111-111111111111')
+    expect(result.success).toBe(true)
+  })
+
+  it.each(['not-a-uuid', '', '123', '11111111-1111-1111-1111', null, undefined, 123])(
+    '無効な値 %j を拒否する',
+    (value) => {
+      expect(seriesIdSchema.safeParse(value).success).toBe(false)
     },
   )
 })

--- a/packages/shared/src/schemas/books-api-schema.ts
+++ b/packages/shared/src/schemas/books-api-schema.ts
@@ -4,6 +4,7 @@ import { storeSchema, thumbnailUrlSchema, storeProductIdSchema } from './book-sc
 // --- パスパラメータ ---
 
 export const userBookIdSchema = z.string().uuid()
+export const seriesIdSchema = z.string().uuid()
 
 // --- POST /api/books リクエスト ---
 
@@ -79,6 +80,7 @@ export const registerBookResponseSchema = z.object({
 // --- 型 ---
 
 export type UserBookId = z.infer<typeof userBookIdSchema>
+export type SeriesId = z.infer<typeof seriesIdSchema>
 export type RegisterBook = z.infer<typeof registerBookSchema>
 export type UpdateUserBook = z.infer<typeof updateUserBookSchema>
 export type GetBooksQuery = z.infer<typeof getBooksQuerySchema>

--- a/supabase/migrations/20260420000001_user_series_view.sql
+++ b/supabase/migrations/20260420000001_user_series_view.sql
@@ -1,0 +1,68 @@
+-- ============================================================
+-- Migration: user_series_view を導入してシリーズ単位の本棚集約を提供
+--
+-- 背景:
+--   #33 で /bookshelf をシリーズ一覧 + 巻詳細の二階層 UI に再構成する。
+--   シリーズ単位の集約 (volume_count, cover_thumbnail_url, stores) を
+--   PostgREST から `count: 'exact'` でページング可能な形で取得したい。
+--
+--   JS 側集約案 (LIMIT 5000 で打ち切り) も検討したが、二度買い防止という
+--   コア価値に対して silently truncate のリスクがあるため view 化を採用。
+--
+-- 設計:
+--   - `WITH (security_invoker = on)` で view 経由 SELECT に呼出ユーザーの
+--     RLS を適用する。`user_books` の `auth.uid() = user_id` ポリシーが
+--     view 経由でも自動的に効く。
+--   - PostgREST 側でも defense in depth として `.eq('user_id', userId)` を
+--     明示する想定 (アプリ層の規約)。
+--   - cover_thumbnail_url は「最小 volume_number で thumbnail_url が NOT NULL の
+--     最初の巻」を correlated subquery で取得。1 巻だけ表紙未取得でカードが
+--     No Cover になる UX 劣化を防ぐ。
+--   - stores は ARRAY サブクエリで「DISTINCT + sort 安定」させる。GROUP BY 内で
+--     ARRAY_AGG(DISTINCT ...) を使うと未指定 ORDER で非決定的になるため。
+--   - last_added_at は将来の「最近追加順」ソートのための余地。
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.user_series_view
+WITH (security_invoker = on)
+AS
+SELECT
+  ub.user_id,
+  s.id   AS series_id,
+  s.title,
+  s.author,
+  COUNT(DISTINCT b.id)::int AS volume_count,
+  (
+    SELECT b2.thumbnail_url
+    FROM public.books b2
+    JOIN public.user_books ub2 ON ub2.book_id = b2.id
+    WHERE b2.series_id = s.id
+      AND ub2.user_id = ub.user_id
+      AND b2.thumbnail_url IS NOT NULL
+    ORDER BY b2.volume_number ASC NULLS LAST, b2.created_at ASC
+    LIMIT 1
+  ) AS cover_thumbnail_url,
+  ARRAY(
+    SELECT DISTINCT ub3.store
+    FROM public.user_books ub3
+    JOIN public.books b3 ON b3.id = ub3.book_id
+    WHERE b3.series_id = s.id
+      AND ub3.user_id = ub.user_id
+    ORDER BY ub3.store
+  ) AS stores,
+  MAX(ub.created_at) AS last_added_at
+FROM public.user_books ub
+JOIN public.books   b ON b.id = ub.book_id
+JOIN public.series  s ON s.id = b.series_id
+GROUP BY ub.user_id, s.id, s.title, s.author;
+
+-- security_invoker = on のため authenticated ロールに SELECT 権を付与すれば
+-- 内部テーブルの RLS が自動的に効く。
+GRANT SELECT ON public.user_series_view TO authenticated;
+
+-- ============================================================
+-- Rollback runbook (Supabase は down migration を管理しないため手動実行):
+--
+--   REVOKE SELECT ON public.user_series_view FROM authenticated;
+--   DROP VIEW IF EXISTS public.user_series_view;
+-- ============================================================

--- a/supabase/migrations/20260420000002_series_trgm_indexes.sql
+++ b/supabase/migrations/20260420000002_series_trgm_indexes.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- Migration: series.title / series.author に pg_trgm GIN インデックスを追加
+--
+-- 背景:
+--   #33 で /bookshelf にシリーズ単位 ILIKE 検索 (`title.ilike` / `author.ilike`)
+--   を導入したが、series 側にインデックスが無いため seq scan になっている。
+--   #31/#33 の経緯で旧 books.title/author 上の B-tree インデックスは DROP 済で、
+--   現状 series 側には UNIQUE 制約 (title, author) しか索引が存在しない。
+--   prefix 一致しか UNIQUE 索引は使えないため、`%キーワード%` の中間一致は seq
+--   scan になり、シリーズ件数が増えると `/bookshelf?q=...` が悪化する。
+--
+--   pg_trgm の GIN インデックスは ILIKE の中間一致 (`%foo%`) にも効くため、
+--   検索性能を中長期的に確保するために導入する。
+--
+-- 変更内容:
+--   1. pg_trgm 拡張を有効化 (PostgreSQL 公式拡張、Supabase で利用可能)
+--   2. series.title に GIN trigram インデックス
+--   3. series.author に GIN trigram インデックス
+--
+-- 影響:
+--   - 検索 (`title.ilike` / `author.ilike`) のクエリプランが index scan に切り替わる
+--   - 書き込み (INSERT/UPDATE) コストは GIN なので B-tree より僅かに重いが、
+--     series の書き込みは scrape でのみ発生 (低頻度) なので無視できる範囲
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_series_title_trgm
+  ON public.series USING gin (title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_series_author_trgm
+  ON public.series USING gin (author gin_trgm_ops);
+
+-- ============================================================
+-- Rollback runbook (Supabase は down migration を管理しないため手動実行):
+--
+--   DROP INDEX IF EXISTS public.idx_series_author_trgm;
+--   DROP INDEX IF EXISTS public.idx_series_title_trgm;
+--   -- pg_trgm は他で使う場合は残す。専有なら DROP EXTENSION pg_trgm;
+-- ============================================================


### PR DESCRIPTION
## Summary

- `/bookshelf` をシリーズカード一覧に変更（最小巻表紙・巻数バッジ・所有ストア・著者）
- `/bookshelf/series/[id]` 新設で巻一覧 (volume_number 昇順) を表示。巻クリックで `buildStoreUrl` 経由でストア商品ページを別タブで開く
- DB view `user_series_view` を `security_invoker = on` で導入し、シリーズ単位の `count: 'exact'` ページング + ILIKE 検索を 1 クエリで実現

Closes #33

## 設計判断

集約方式は当初 JS 集約案 (PostgREST 1 query → JS で `series_id` 集約 + LIMIT 5000) を検討したが、architect レビューで「行数上限超過時の silently truncate が二度買い防止というコア価値と直接衝突」「`count: 'exact'` でシリーズ単位の正確なページングが取れない」と指摘され、**DB view 案** に切替。詳細は `docs/specs/architecture.md` の ADR 6.2 を参照。

## 主要な変更

### DB
- `supabase/migrations/20260420000001_user_series_view.sql` — `user_series_view` (security_invoker=on, GRANT TO authenticated)
- `supabase/migrations/20260420000002_series_trgm_indexes.sql` — `pg_trgm` GIN インデックスで ILIKE 検索の中間一致を index scan 化

### データ層
- `apps/web/lib/books/get-user-series.ts` — シリーズページング + 検索
- `apps/web/lib/books/get-series-detail.ts` — 1-query inner join (user_id + series_id eq) で IDOR 防御
- `apps/web/lib/books/postgrest-helpers.ts` — `buildQuotedIlikePattern` を切り出し DRY 化
- `packages/shared` に `seriesIdSchema = z.string().uuid()` 追加

### UI
- 新規 `SeriesCard` / `SeriesGallery` (情報密度に合わせ `grid-cols-1 sm:grid-cols-2 ... xl:grid-cols-5`)
- 既存 `BookGallery` を `isSearching: boolean` → `emptyFallback?: ReactNode` に refactor (責務分離)
- 両 page に `loading.tsx` (skeleton) 追加

### ページ
- `/bookshelf/page.tsx` を `getUserSeries` ベースに書き換え
- `/bookshelf/series/[id]/page.tsx` 新設
  - `seriesIdSchema.safeParse` で UUID 形式 validate → `notFound()`
  - `getSeriesDetail` が null → `notFound()` で他ユーザー所持 series と存在しない series を同等扱い (IDOR 防御)
  - Breadcrumb の「本棚」リンクは `searchParams.q` を保持して戻る (UX)
  - `force-dynamic` を `/bookshelf` と統一

### ドキュメント
- `docs/specs/DB_SCHEMA.md` — `user_series_view` セクション + Migration History + series trgm インデックス表
- `docs/specs/architecture.md` — ADR 6.2 (view 戦略 + 運用注意点) / 6.3 (searchParams 保持規約)

## Code Review 対応事項 (HIGH/MEDIUM/LOW 全て対応済)

- HIGH: `series.title` / `series.author` に `pg_trgm` GIN インデックス追加
- HIGH: ADR 6.2 に `security_invoker` の将来リスク・correlated subquery cost・stores 依存関係を追記
- MEDIUM: `getSeriesDetail` に PostgREST embedded filter のセマンティクスをコメント明示 + 全行同一 series_id の dev 環境 assertion
- MEDIUM: DB_SCHEMA.md の view SQL ブロックに「省略あり/migration 参照」注記
- LOW: 詳細ページの `BookGallery` に `emptyFallback` 追加 (TOCTOU 保険)
- LOW: `seriesIdSchema` の単体テスト追加

## セキュリティレビュー結果

`SAFE TO MERGE`。CRITICAL/HIGH なし。確認された防御:

- IDOR: 二重 eq フィルタ + null → notFound で存在/非存在の差異を消去
- RLS 伝播: `security_invoker = on` + アプリ層 defense in depth (`.eq('user_id', userId)`)
- SQL Injection: PostgREST parameterized + 2 段 ILIKE エスケープ
- XSS: React JSX 自動エスケープ依存、`dangerouslySetInnerHTML` 不使用
- DoS: q 200 文字切り詰め + DEFAULT_LIMIT 固定
- SSRF: サーバーサイド fetch なし

## Test plan

- [x] `pnpm -r test` — 622 件 PASS (shared 235 / extension 120 / web 267)
- [x] `pnpm -r lint` / `pnpm format:check` — クリーン
- [x] `pnpm -r build` — 成功 (`/bookshelf/series/[id]` がルート一覧に登場)
- [x] Supabase MCP で view 動作確認 (volume_count・stores・cover_thumbnail_url の集約結果が期待通り)
- [x] `EXPLAIN ANALYZE` でシリーズ検索 0.694ms (現状は seq scan、件数増加時に trgm index に切替)
- [x] dev で `/bookshelf` でシリーズカード表示・巻数バッジ確認
- [ ] シリーズカードクリック → `/bookshelf/series/[id]` で巻一覧 (volume_number 昇順) 確認
- [ ] 巻クリック → 別タブで Kindle/DMM 商品ページ
- [x] `?q=ワンピ` でシリーズ絞り込み + 詳細遷移 → 戻る で q が保持される
- [x] URL 直叩き `/bookshelf/series/00000000-...` → 404
- [x] `/bookshelf/series/not-a-uuid` → 404 (zod validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * シリーズ詳細ページを追加しました
  * シリーズギャラリーの閲覧機能を実装しました

* **改善**
  * ページ読み込み中のプレースホルダーUIを追加しました
  * エラー画面の表示機能を追加しました
  * 検索クエリを戻るリンクに保持するようにしました
  * シリーズの検索とフィルタリング機能を強化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->