### PR TITLE
docs: sync CONTRIBUTING.md with current code structure

### DIFF
--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -79,9 +79,13 @@ cp .env.example apps/web/.env.local
 
 ### packages/shared
 
-| コマンド                              | 説明                     |
-| ------------------------------------- | ------------------------ |
-| `pnpm --filter @bookhub/shared build` | 型定義・スキーマをビルド |
+| コマンド                                      | 説明                                          |
+| --------------------------------------------- | --------------------------------------------- |
+| `pnpm --filter @bookhub/shared build`         | 型定義・スキーマ・Parser をビルド             |
+| `pnpm --filter @bookhub/shared dev`           | TypeScript の watch モード                    |
+| `pnpm --filter @bookhub/shared test`          | テスト実行（Zod スキーマ・Parser・deep-link） |
+| `pnpm --filter @bookhub/shared test:watch`    | テストをウォッチモードで実行                  |
+| `pnpm --filter @bookhub/shared test:coverage` | テストカバレッジレポート生成                  |
 
 ## 環境変数リファレンス
 
@@ -225,14 +229,15 @@ pnpm --filter extension test:coverage
   - タイムアウト処理（`waitForElement()`）
   - Service Worker への送信
 
-- **Parser** (`src/content/shared/__tests__/parser.test.ts`):
-  - 巻数抽出（複数パターン: 「第1巻」「1巻」「(1)」「Vol.1」等）
-  - シリーズタイトル正規化（巻数表記・修飾語の除去）
-  - URL バリデーション
-
 - **Sender** (`src/content/shared/__tests__/sender.test.ts`):
   - Service Worker へのメッセージ送信
   - エラーハンドリング
+
+- **Scrape Session** (`src/content/shared/__tests__/scrape-session.test.ts`):
+  - 累積セッションのライフサイクル（開始・更新・完了・期限切れ）
+
+> Parser は `packages/shared/src/parser/__tests__/title-parser.test.ts` に移管済み。
+> Web 側の defensive parse 用にも同一実装が共有される（詳細は後述「Parser」節）。
 
 ## API エンドポイントリファレンス
 
@@ -438,6 +443,31 @@ Authorization: Bearer <token>
 
 レスポンス: 更新後の `BookWithStore` オブジェクト（200 OK）。存在しない場合は 404。
 
+### `GET /api/books/search` — 外部 API で書籍を検索
+
+楽天ブックス API（プライマリ）または Google Books API（フォールバック）を使って書籍を検索します。手動登録 UI のための候補取得用エンドポイント。
+
+#### リクエスト
+
+```text
+GET /api/books/search?q=ワンピース&page=1&limit=10
+Authorization: Bearer <token>
+```
+
+| パラメータ | 型     | 必須 | 説明                                       |
+| ---------- | ------ | ---- | ------------------------------------------ |
+| `q`        | string | Yes  | 検索クエリ（タイトル/著者名、1〜200 文字） |
+| `page`     | number | No   | ページ番号（デフォルト: 1、最大: 1000）    |
+| `limit`    | number | No   | 件数（デフォルト: 10、最大: 30）           |
+
+#### フォールバック戦略
+
+1. 楽天ブックス API で検索（`RAKUTEN_APP_ID` 設定時）
+2. 結果なし or エラー → Google Books API にフォールバック（`GOOGLE_BOOKS_API_KEY` 設定時）
+3. 両方失敗 → `source: "none"` + エラー情報を返す（200 レスポンス）
+
+詳細仕様は `docs/specs/openapi.yaml` の `/api/books/search` セクション参照。
+
 ### `DELETE /api/books/{id}` — 所持書籍の削除
 
 user_books レコードを削除します。books マスタは削除しません。`{id}` は user_books.id（UUID）。
@@ -489,11 +519,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 })
 ```
 
-### Parser（src/content/shared/parser.ts）
+### Parser（packages/shared/src/parser/title-parser.ts）
 
-生データから共通の `ScrapeBook[]` 型に正規化：
+生データから共通の `ScrapeBook[]` 型に正規化。Chrome 拡張と Web の両方で利用するため
+`packages/shared` に配置している（拡張ビルドの旧バージョンが流入した汚染データを
+サーバ側で再 parse する defense in depth 用途）。
 
 ```typescript
+import { extractVolumeNumber, extractSeriesTitle, parseBooks } from '@bookhub/shared'
+
 // 巻数抽出
 extractVolumeNumber('ワンピース 107巻') // → 107
 
@@ -507,6 +541,8 @@ const books = parseBooks(rawBooks, 'kindle')
 対応パターン：
 
 - 「第1巻」「1巻」「(1)」「(01)」「Vol.1」「vol 1」
+- 末尾の Kindle 出版社ラベル除去：「(ジャンプコミックスDIGITAL)」「(BOOKS)」等
+- 全角英数字の正規化（`normalizeWidth`）
 - 修飾語除去：「特装版」「限定版」「通常版」
 
 ### ストレージ操作


### PR DESCRIPTION
## Summary

`docs/guides/CONTRIBUTING.md` がソースオブトゥルース (package.json / .env.example / openapi.yaml) との同期が取れていなかったため update-docs ワークフローで更新。Issue #31 で Parser を `apps/extension` から `packages/shared` に移管した際の参照漏れと、Issue #32 で追加した `/api/books/search` の API 記述漏れが主な対象。

## 主な変更

### Parser パス修正 (#31 の移管に追従)

- `apps/extension/src/content/shared/parser.ts` → `packages/shared/src/parser/title-parser.ts`
- `apps/extension/src/content/shared/__tests__/parser.test.ts` → `packages/shared/src/parser/__tests__/title-parser.test.ts`
- import 例を `import { ... } from '@bookhub/shared'` 形式に更新

### `packages/shared` コマンド表の補完

`build` のみ記載されていたが、実際には `dev` / `test` / `test:watch` / `test:coverage` も存在する。

### `/api/books/search` API リファレンス追加

`docs/specs/openapi.yaml` には存在するが CONTRIBUTING.md の API リファレンス節に未記載だったため追記。検索パラメータ・フォールバック戦略 (楽天 → Google Books) も含む。

### Parser 対応パターン追記

#33 周辺で追加した「全角英数字正規化 (`normalizeWidth`)」と「Kindle 出版社ラベル除去 (DIGITAL/BOOKS 等)」を対応パターン一覧に追加。

### Chrome 拡張テストの種類更新

parser.test.ts 削除に合わせて、Scrape Session テストの記載を追加。Parser テストは shared 側に移った旨を注記。

## Test plan

- [x] `pnpm format:check` クリーン
- [x] `pnpm lint` クリーン
- [x] CONTRIBUTING.md のリンク先パスが実在することを確認
- [x] CONTRIBUTING.md の env 表が `.env.example` の全エントリをカバー
- [x] CONTRIBUTING.md の API 表が `openapi.yaml` の全 path をカバー

## 別途フラグ済 (本 PR 範囲外)

以下は変更日時のみで自動判定したフラグ。実コードとの差分確認は手動で:

- `docs/specs/sequence_diagrams.md` (16 日経過) — series UI 二階層化が反映されているか
- `docs/specs/tech_stack.md` (16 日経過) — pg_trgm 拡張・user_series_view 等が反映されているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)