### PR TITLE
refactor(web): sendTokenToExtension のメッセージ型を @bookhub/shared と統一 (closes #27)

### DIFF
--- a/apps/web/lib/extension/__tests__/send-token.test.ts
+++ b/apps/web/lib/extension/__tests__/send-token.test.ts
@@ -105,4 +105,44 @@ describe('sendTokenToExtension', () => {
     const { sendTokenToExtension } = await import('../send-token')
     await expect(sendTokenToExtension('token')).resolves.toBeUndefined()
   })
+
+  it('空文字列の token は shared スキーマで弾かれ sendMessage を呼ばない', async () => {
+    process.env.NEXT_PUBLIC_EXTENSION_ID = 'my-extension-id'
+    const sendMessage = vi.fn()
+    ;(globalThis as { chrome?: unknown }).chrome = {
+      runtime: { sendMessage, id: 'browser-ext-id', lastError: null },
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const { sendTokenToExtension } = await import('../send-token')
+    await sendTokenToExtension('')
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[sendTokenToExtension] invalid message, skipping send',
+      expect.objectContaining({ path: ['token'] }),
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  it('8192 文字を超える token は shared スキーマで弾かれ sendMessage を呼ばない', async () => {
+    process.env.NEXT_PUBLIC_EXTENSION_ID = 'my-extension-id'
+    const sendMessage = vi.fn()
+    ;(globalThis as { chrome?: unknown }).chrome = {
+      runtime: { sendMessage, id: 'browser-ext-id', lastError: null },
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const { sendTokenToExtension } = await import('../send-token')
+    await sendTokenToExtension('a'.repeat(8193))
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[sendTokenToExtension] invalid message, skipping send',
+      expect.objectContaining({ path: ['token'] }),
+    )
+
+    warnSpy.mockRestore()
+  })
 })

--- a/apps/web/lib/extension/__tests__/send-token.test.ts
+++ b/apps/web/lib/extension/__tests__/send-token.test.ts
@@ -114,16 +114,18 @@ describe('sendTokenToExtension', () => {
     }
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
-    const { sendTokenToExtension } = await import('../send-token')
-    await sendTokenToExtension('')
+    try {
+      const { sendTokenToExtension } = await import('../send-token')
+      await sendTokenToExtension('')
 
-    expect(sendMessage).not.toHaveBeenCalled()
-    expect(warnSpy).toHaveBeenCalledWith(
-      '[sendTokenToExtension] invalid message, skipping send',
-      expect.objectContaining({ path: ['token'] }),
-    )
-
-    warnSpy.mockRestore()
+      expect(sendMessage).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[sendTokenToExtension] invalid message, skipping send',
+        expect.objectContaining({ path: ['token'] }),
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('8192 文字を超える token は shared スキーマで弾かれ sendMessage を呼ばない', async () => {
@@ -134,15 +136,17 @@ describe('sendTokenToExtension', () => {
     }
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
-    const { sendTokenToExtension } = await import('../send-token')
-    await sendTokenToExtension('a'.repeat(8193))
+    try {
+      const { sendTokenToExtension } = await import('../send-token')
+      await sendTokenToExtension('a'.repeat(8193))
 
-    expect(sendMessage).not.toHaveBeenCalled()
-    expect(warnSpy).toHaveBeenCalledWith(
-      '[sendTokenToExtension] invalid message, skipping send',
-      expect.objectContaining({ path: ['token'] }),
-    )
-
-    warnSpy.mockRestore()
+      expect(sendMessage).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[sendTokenToExtension] invalid message, skipping send',
+        expect.objectContaining({ path: ['token'] }),
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 })

--- a/apps/web/lib/extension/send-token.ts
+++ b/apps/web/lib/extension/send-token.ts
@@ -5,15 +5,23 @@
 // - chrome グローバルが未定義 (Firefox/Safari/SSR)
 // - NEXT_PUBLIC_EXTENSION_ID が未設定 (拡張機能未運用)
 // - 拡張機能が未インストール (chrome.runtime.lastError が発生)
+// - 送信前 safeParse でメッセージが shared スキーマに反した場合 (warn してスキップ)
 
-type ExternalRequest = { type: 'SET_ACCESS_TOKEN'; token: string } | { type: 'CLEAR_ACCESS_TOKEN' }
+import {
+  clearAccessTokenMessageSchema,
+  setAccessTokenMessageSchema,
+  type ClearAccessTokenMessage,
+  type SetAccessTokenMessage,
+} from '@bookhub/shared'
+
+type SendableMessage = SetAccessTokenMessage | ClearAccessTokenMessage
 
 declare const chrome:
   | {
       runtime?: {
         sendMessage?: (
           extensionId: string,
-          message: ExternalRequest,
+          message: SendableMessage,
           callback?: (response: unknown) => void,
         ) => void
         lastError?: { message?: string } | null
@@ -27,8 +35,23 @@ export async function sendTokenToExtension(token: string | null): Promise<void> 
   if (typeof chrome === 'undefined') return
   if (!chrome?.runtime?.sendMessage) return
 
-  const message: ExternalRequest =
-    token === null ? { type: 'CLEAR_ACCESS_TOKEN' } : { type: 'SET_ACCESS_TOKEN', token }
+  const parsed =
+    token === null
+      ? clearAccessTokenMessageSchema.safeParse({ type: 'CLEAR_ACCESS_TOKEN' })
+      : setAccessTokenMessageSchema.safeParse({ type: 'SET_ACCESS_TOKEN', token })
+
+  if (!parsed.success) {
+    // shared スキーマ違反は呼び出し側に伝播させない (no-op 設計を維持)。
+    // path / code を出力して運用時に「token 空」「token 上限超え」を区別可能にする。
+    const issue = parsed.error.issues[0]
+    console.warn('[sendTokenToExtension] invalid message, skipping send', {
+      path: issue?.path,
+      code: issue?.code,
+    })
+    return
+  }
+
+  const message = parsed.data
 
   return new Promise<void>((resolve) => {
     try {

--- a/apps/web/lib/extension/send-token.ts
+++ b/apps/web/lib/extension/send-token.ts
@@ -35,6 +35,8 @@ export async function sendTokenToExtension(token: string | null): Promise<void> 
   if (typeof chrome === 'undefined') return
   if (!chrome?.runtime?.sendMessage) return
 
+  // CLEAR は現状フィールドを持たないため safeParse は常に成功するが、将来 schema に
+  // 制約が追加された場合も自動でガードされるよう対称的に safeParse を通す。
   const parsed =
     token === null
       ? clearAccessTokenMessageSchema.safeParse({ type: 'CLEAR_ACCESS_TOKEN' })
@@ -42,11 +44,13 @@ export async function sendTokenToExtension(token: string | null): Promise<void> 
 
   if (!parsed.success) {
     // shared スキーマ違反は呼び出し側に伝播させない (no-op 設計を維持)。
-    // path / code を出力して運用時に「token 空」「token 上限超え」を区別可能にする。
+    // path / code / message を出力して運用時に原因特定を素早くできるようにする
+    // (Zod の issue.message は安全。token 本体はログに出さない)。
     const issue = parsed.error.issues[0]
     console.warn('[sendTokenToExtension] invalid message, skipping send', {
       path: issue?.path,
       code: issue?.code,
+      message: issue?.message,
     })
     return
   }


### PR DESCRIPTION
## 概要

Issue #27 の対応。`apps/web/lib/extension/send-token.ts` で送信メッセージ型 `ExternalRequest` がローカル定義されており、`packages/shared/src/schemas/external-message-schema.ts` の `setAccessTokenMessageSchema` / `clearAccessTokenMessageSchema` と二重管理になっていた。これを shared スキーマに統一し、送信前 `safeParse` による fail-fast バリデーションを追加する。

## 完了条件 (issue #27)

- [x] ローカル `ExternalRequest` 型を削除
- [x] `@bookhub/shared` から `setAccessTokenMessageSchema` / `clearAccessTokenMessageSchema` を import
- [x] 送信前に `safeParse` でバリデーション、失敗時は `console.warn` してスキップ (no-op 設計を維持)

## 主要変更

### `apps/web/lib/extension/send-token.ts`

- ローカル `type ExternalRequest` を削除し、`SetAccessTokenMessage | ClearAccessTokenMessage` に置換
- `setAccessTokenMessageSchema` / `clearAccessTokenMessageSchema` を import し、送信メッセージを `safeParse` で検証
- バリデーション失敗時は `console.warn` で `path` / `code` / Zod の `issue.message` を出力してスキップ。token 本体はログに出さない
- CLEAR ルートは現状フィールドが無く safeParse は常に成功するが、将来 schema に制約が追加された場合の自動ガードとして対称的に safeParse を通す (コメントで意図を明示)

### テスト追加

- 空文字列 token (`min(1)` 違反) → `sendMessage` 未呼び出し + warn 出力
- 8192 文字超過 token (`max(8192)` 違反) → 同上
- 境界値の網羅は `packages/shared` 側の責務とし、web 側は「バリデーション失敗時に送信を抑止する契約」のみを検証

## レビュー対応

architect レビュー → code-review 2 段階を通過。

- architect: スコープ確定 (今回は send-token のみ)、`trigger-kindle-scrape.ts` の同様統一は別 Issue 推奨、`messaging.ts` 抽象化は 3 ファイル目発生時 (= dmm 追加時) にトリガー
- code-review: CRITICAL/HIGH 0、MEDIUM 2 + LOW 2 を指摘 → デッドパス意図のコメント / warn ログ強化 / `try/finally` での `mockRestore` を反映

## スコープ外 (別 Issue 推奨)

- `apps/web/lib/extension/trigger-kindle-scrape.ts` の `ExternalRequest` ローカル定義削除
- `declare const chrome` の重複統合 (3 ファイル目発生時に `apps/web/lib/extension/messaging.ts` に統合)

## Test plan

- [x] `pnpm --filter web test -- send-token --run` (293 件 pass、+2 件追加)
- [x] `pnpm lint` 通過
- [x] `pnpm format:check` 通過
- [x] `pnpm build` 通過 (Cloudflare Pages Edge 対応維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * トークン入力の検証を強化しました。空文字列または8192文字を超えるトークンは適切に拒否されるようになります。

* **Tests**
  * トークン検証ロジックのテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->