### PR TITLE
refactor(web): CSP script-src を nonce + strict-dynamic 方式に置き換え (#28)

### DIFF
--- a/apps/web/__tests__/middleware.test.ts
+++ b/apps/web/__tests__/middleware.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const updateSessionMock = vi.fn()
+
+vi.mock('@/lib/supabase/middleware', () => ({
+  updateSession: (req: NextRequest, options?: { nonce?: string }) =>
+    updateSessionMock(req, options),
+}))
+
+import { middleware } from '../middleware'
+
+function createTestRequest(pathname = '/'): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: {
+      pathname,
+      clone: () => new URL(`http://localhost:3000${pathname}`),
+    },
+    cookies: { getAll: () => [], set: () => {} },
+  } as unknown as NextRequest
+}
+
+function makeFakeResponse() {
+  return { headers: new Headers() }
+}
+
+describe('middleware (CSP nonce オーケストレータ)', () => {
+  beforeEach(() => {
+    updateSessionMock.mockReset()
+  })
+
+  it('updateSession に nonce option を渡す', async () => {
+    updateSessionMock.mockResolvedValue(makeFakeResponse())
+
+    await middleware(createTestRequest('/'))
+
+    expect(updateSessionMock).toHaveBeenCalledOnce()
+    const [, options] = updateSessionMock.mock.calls[0]
+    expect(options).toEqual(expect.objectContaining({ nonce: expect.any(String) }))
+    expect((options as { nonce: string }).nonce.length).toBeGreaterThan(0)
+  })
+
+  it('レスポンスに Content-Security-Policy header を set する', async () => {
+    const fakeResponse = makeFakeResponse()
+    updateSessionMock.mockResolvedValue(fakeResponse)
+
+    const response = (await middleware(createTestRequest('/'))) as unknown as {
+      headers: Headers
+    }
+
+    const csp = response.headers.get('Content-Security-Policy')
+    expect(csp).toBeTruthy()
+    expect(csp).toContain('script-src')
+    expect(csp).toContain("'strict-dynamic'")
+    expect(csp).toContain("'self'")
+  })
+
+  it('CSP に埋め込まれる nonce と updateSession に渡す nonce が一致する', async () => {
+    updateSessionMock.mockResolvedValue(makeFakeResponse())
+
+    const response = (await middleware(createTestRequest('/'))) as unknown as {
+      headers: Headers
+    }
+
+    const passedNonce = (updateSessionMock.mock.calls[0][1] as { nonce: string }).nonce
+    const csp = response.headers.get('Content-Security-Policy') ?? ''
+    expect(csp).toContain(`'nonce-${passedNonce}'`)
+  })
+
+  it('CSP は production 経路で unsafe-inline / unsafe-eval を含まない', async () => {
+    updateSessionMock.mockResolvedValue(makeFakeResponse())
+
+    const response = (await middleware(createTestRequest('/'))) as unknown as {
+      headers: Headers
+    }
+
+    const csp = response.headers.get('Content-Security-Policy') ?? ''
+    const scriptSrc = csp.split('; ').find((d) => d.startsWith('script-src ')) ?? ''
+    expect(scriptSrc).not.toContain("'unsafe-inline'")
+    // テスト環境 NODE_ENV=test 想定。dev でない経路でのスナップショット。
+    expect(scriptSrc).not.toContain("'unsafe-eval'")
+  })
+
+  it('リクエスト毎に異なる nonce を生成する', async () => {
+    updateSessionMock.mockResolvedValue(makeFakeResponse())
+
+    await middleware(createTestRequest('/'))
+    await middleware(createTestRequest('/'))
+
+    const nonce1 = (updateSessionMock.mock.calls[0][1] as { nonce: string }).nonce
+    const nonce2 = (updateSessionMock.mock.calls[1][1] as { nonce: string }).nonce
+    expect(nonce1).not.toBe(nonce2)
+  })
+
+  it('updateSession が redirect を返した経路でも CSP を上書きで set する', async () => {
+    // updateSession が既に何らかの header をセットしている状況を想定
+    const fakeResponse = { headers: new Headers({ Location: '/login' }) }
+    updateSessionMock.mockResolvedValue(fakeResponse)
+
+    const response = (await middleware(createTestRequest('/bookshelf'))) as unknown as {
+      headers: Headers
+    }
+
+    expect(response.headers.get('Content-Security-Policy')).toBeTruthy()
+    expect(response.headers.get('Location')).toBe('/login')
+  })
+})

--- a/apps/web/__tests__/middleware.test.ts
+++ b/apps/web/__tests__/middleware.test.ts
@@ -30,15 +30,25 @@ describe('middleware (CSP nonce オーケストレータ)', () => {
     updateSessionMock.mockReset()
   })
 
-  it('updateSession に nonce option を渡す', async () => {
+  it('updateSession に nonce と csp option を渡す', async () => {
     updateSessionMock.mockResolvedValue(makeFakeResponse())
 
     await middleware(createTestRequest('/'))
 
     expect(updateSessionMock).toHaveBeenCalledOnce()
     const [, options] = updateSessionMock.mock.calls[0]
-    expect(options).toEqual(expect.objectContaining({ nonce: expect.any(String) }))
-    expect((options as { nonce: string }).nonce.length).toBeGreaterThan(0)
+    expect(options).toEqual(
+      expect.objectContaining({
+        nonce: expect.any(String),
+        csp: expect.any(String),
+      }),
+    )
+    const typed = options as { nonce: string; csp: string }
+    expect(typed.nonce.length).toBeGreaterThan(0)
+    // csp は同じ nonce を含む完全な CSP 文字列であること (Next.js の getScriptNonceFromHeader が
+    // request.headers から抽出するために必要)
+    expect(typed.csp).toContain(`'nonce-${typed.nonce}'`)
+    expect(typed.csp).toContain('script-src')
   })
 
   it('レスポンスに Content-Security-Policy header を set する', async () => {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter, JetBrains_Mono, Noto_Sans_JP, Orbitron } from 'next/font/google'
+import { headers } from 'next/headers'
 
 import { ThemeProvider } from '@/components/theme-provider'
 
@@ -41,11 +42,20 @@ export const metadata: Metadata = {
   description: '漫画ヘビーユーザー向け本棚管理・二度買い防止サービス',
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  // middleware が per-request で生成した nonce を受け取り、next-themes の inline 初期化スクリプトに
+  // 渡す。これがないと strict-dynamic 配下で next-themes の inline script が CSP 違反でブロックされ、
+  // FOUC やテーマ初期化失敗を引き起こす。Next.js が出力する RSC ハイドレーションスクリプトには
+  // x-nonce request header から自動付与されるため、追加対応は不要。
+  // exactOptionalPropertyTypes: true 配下で nonce?: string に undefined を直接渡せないため、
+  // x-nonce が無い経路 (middleware を通らない / static 化されたケース) では prop ごと省略する。
+  const nonce = (await headers()).get('x-nonce')
+  const themeProviderNonce = nonce ? { nonce } : {}
+
   return (
     <html
       lang="ja"
@@ -58,6 +68,7 @@ export default function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
+          {...themeProviderNonce}
         >
           {children}
         </ThemeProvider>

--- a/apps/web/lib/csp/__tests__/build-csp.test.ts
+++ b/apps/web/lib/csp/__tests__/build-csp.test.ts
@@ -37,14 +37,16 @@ describe('buildContentSecurityPolicy', () => {
     expect(scriptSrc).not.toContain("'unsafe-inline'")
   })
 
-  it('img-src に @bookhub/shared の許可ホスト一覧が反映される', () => {
+  it('img-src に @bookhub/shared の許可ホストが exact + サブドメインで反映される', () => {
     const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: false })
     const imgSrc = getDirective(csp, 'img-src') ?? ''
 
     expect(imgSrc).toContain("'self'")
     expect(imgSrc).toContain('data:')
     for (const host of ALLOWED_THUMBNAIL_HOSTS) {
+      // thumbnailUrlSchema は exact + サブドメインを許可するため CSP も両方を出す
       expect(imgSrc).toContain(`https://${host}`)
+      expect(imgSrc).toContain(`https://*.${host}`)
     }
   })
 

--- a/apps/web/lib/csp/__tests__/build-csp.test.ts
+++ b/apps/web/lib/csp/__tests__/build-csp.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { ALLOWED_THUMBNAIL_HOSTS } from '@bookhub/shared'
+import { buildContentSecurityPolicy } from '../build-csp'
+
+const NONCE = 'test-nonce-value=='
+
+function getDirective(csp: string, name: string): string | undefined {
+  return csp.split('; ').find((directive) => directive.startsWith(`${name} `) || directive === name)
+}
+
+describe('buildContentSecurityPolicy', () => {
+  it('production の script-src に nonce と strict-dynamic を含める', () => {
+    const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: false })
+    const scriptSrc = getDirective(csp, 'script-src')
+
+    expect(scriptSrc).toBeDefined()
+    expect(scriptSrc).toContain(`'nonce-${NONCE}'`)
+    expect(scriptSrc).toContain("'strict-dynamic'")
+    expect(scriptSrc).toContain("'self'")
+  })
+
+  it('production の script-src に unsafe-inline / unsafe-eval を含めない', () => {
+    const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: false })
+    const scriptSrc = getDirective(csp, 'script-src') ?? ''
+
+    expect(scriptSrc).not.toContain("'unsafe-inline'")
+    expect(scriptSrc).not.toContain("'unsafe-eval'")
+  })
+
+  it('development の script-src には unsafe-eval を含める (React Refresh runtime 用)', () => {
+    const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: true })
+    const scriptSrc = getDirective(csp, 'script-src') ?? ''
+
+    expect(scriptSrc).toContain("'unsafe-eval'")
+    expect(scriptSrc).toContain(`'nonce-${NONCE}'`)
+    expect(scriptSrc).toContain("'strict-dynamic'")
+    expect(scriptSrc).not.toContain("'unsafe-inline'")
+  })
+
+  it('img-src に @bookhub/shared の許可ホスト一覧が反映される', () => {
+    const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: false })
+    const imgSrc = getDirective(csp, 'img-src') ?? ''
+
+    expect(imgSrc).toContain("'self'")
+    expect(imgSrc).toContain('data:')
+    for (const host of ALLOWED_THUMBNAIL_HOSTS) {
+      expect(imgSrc).toContain(`https://${host}`)
+    }
+  })
+
+  it('style-src は当面 unsafe-inline を残す (Phase 4 で再評価)', () => {
+    const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: false })
+    const styleSrc = getDirective(csp, 'style-src') ?? ''
+
+    expect(styleSrc).toContain("'self'")
+    expect(styleSrc).toContain("'unsafe-inline'")
+  })
+
+  it('Supabase との接続を許可する connect-src を含む', () => {
+    const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: false })
+    const connectSrc = getDirective(csp, 'connect-src') ?? ''
+
+    expect(connectSrc).toContain("'self'")
+    expect(connectSrc).toContain('https://*.supabase.co')
+    expect(connectSrc).toContain('wss://*.supabase.co')
+  })
+
+  it('クリックジャッキング/オブジェクト埋め込み防御の固定値ディレクティブを含む', () => {
+    const csp = buildContentSecurityPolicy({ nonce: NONCE, isDev: false })
+
+    expect(getDirective(csp, 'frame-ancestors')).toBe("frame-ancestors 'none'")
+    expect(getDirective(csp, 'object-src')).toBe("object-src 'none'")
+    expect(getDirective(csp, 'worker-src')).toBe("worker-src 'none'")
+    expect(getDirective(csp, 'base-uri')).toBe("base-uri 'self'")
+    expect(getDirective(csp, 'form-action')).toBe("form-action 'self'")
+    expect(getDirective(csp, 'default-src')).toBe("default-src 'self'")
+    expect(getDirective(csp, 'font-src')).toBe("font-src 'self' data:")
+  })
+
+  it('異なる nonce が独立して埋め込まれる', () => {
+    const csp1 = buildContentSecurityPolicy({ nonce: 'aaa', isDev: false })
+    const csp2 = buildContentSecurityPolicy({ nonce: 'bbb', isDev: false })
+
+    expect(csp1).toContain("'nonce-aaa'")
+    expect(csp2).toContain("'nonce-bbb'")
+    expect(csp1).not.toContain("'nonce-bbb'")
+    expect(csp2).not.toContain("'nonce-aaa'")
+  })
+})

--- a/apps/web/lib/csp/__tests__/generate-nonce.test.ts
+++ b/apps/web/lib/csp/__tests__/generate-nonce.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { generateNonce } from '../generate-nonce'
+
+describe('generateNonce', () => {
+  it('base64 形式の文字列を返す', () => {
+    const nonce = generateNonce()
+    expect(nonce).toMatch(/^[A-Za-z0-9+/]+={0,2}$/)
+  })
+
+  it('128bit (16 bytes) を base64 エンコードした 24 文字を返す', () => {
+    // 16 bytes を base64 すると "...==" 含めて 24 文字 (4 * ceil(16 / 3))
+    const nonce = generateNonce()
+    expect(nonce).toHaveLength(24)
+  })
+
+  it('連続呼び出しで衝突しない', () => {
+    const samples = new Set<string>()
+    for (let i = 0; i < 100; i++) {
+      samples.add(generateNonce())
+    }
+    expect(samples.size).toBe(100)
+  })
+
+  it('btoa できる文字列のみを生成する', () => {
+    // base64 デコードして 16 bytes に戻ること
+    const nonce = generateNonce()
+    const decoded = atob(nonce)
+    expect(decoded).toHaveLength(16)
+  })
+})

--- a/apps/web/lib/csp/build-csp.ts
+++ b/apps/web/lib/csp/build-csp.ts
@@ -1,0 +1,37 @@
+import { ALLOWED_THUMBNAIL_HOSTS } from '@bookhub/shared'
+
+const IMG_HOSTS_CSP = ALLOWED_THUMBNAIL_HOSTS.map((host) => `https://${host}`).join(' ')
+
+export type BuildCspOptions = {
+  nonce: string
+  isDev: boolean
+}
+
+// 本番 script-src は `'self' 'nonce-{nonce}' 'strict-dynamic'` で固定。`strict-dynamic` を指定する以上、
+// `'self'` や URL 許可リストはブラウザに無視されるが、CSP2 互換のフォールバックとして残す
+// (CSP3 非対応ブラウザは `'strict-dynamic'` を無視し、`'self'` で評価する)。
+//
+// dev は React Refresh runtime が eval() を使うため `'unsafe-eval'` を残す。これがないと
+// HMR runtime が初期化されず client component がサイレントに動作不能になる。
+//
+// style-src はフェーズ 4 で実機検証後に判断するため、暫定で `'unsafe-inline'` を残す。
+// Tailwind v4 / shadcn-ui (Radix Popper 等) が動的 inline style を出すため nonce 化判断は要観測。
+export function buildContentSecurityPolicy({ nonce, isDev }: BuildCspOptions): string {
+  const scriptSrc = isDev
+    ? `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval'`
+    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`
+
+  return [
+    "default-src 'self'",
+    `img-src 'self' data: ${IMG_HOSTS_CSP}`,
+    scriptSrc,
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self' data:",
+    "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+    "worker-src 'none'",
+  ].join('; ')
+}

--- a/apps/web/lib/csp/build-csp.ts
+++ b/apps/web/lib/csp/build-csp.ts
@@ -14,8 +14,10 @@ export type BuildCspOptions = {
 // dev は React Refresh runtime が eval() を使うため `'unsafe-eval'` を残す。これがないと
 // HMR runtime が初期化されず client component がサイレントに動作不能になる。
 //
-// style-src はフェーズ 4 で実機検証後に判断するため、暫定で `'unsafe-inline'` を残す。
-// Tailwind v4 / shadcn-ui (Radix Popper 等) が動的 inline style を出すため nonce 化判断は要観測。
+// style-src は当面 `'unsafe-inline'` を残す。Tailwind v4 / shadcn-ui (Radix Popper 等) が動的
+// inline style を出す可能性があるため (Issue #28 Phase 4 の判断、ADR は docs/specs/architecture.md
+// §6.5)。将来 inline style 利用無しが確証できた時点で `'self' 'nonce-{nonce}'` への厳格化を
+// 別 Issue で検討する。
 export function buildContentSecurityPolicy({ nonce, isDev }: BuildCspOptions): string {
   const scriptSrc = isDev
     ? `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval'`

--- a/apps/web/lib/csp/build-csp.ts
+++ b/apps/web/lib/csp/build-csp.ts
@@ -1,6 +1,13 @@
 import { ALLOWED_THUMBNAIL_HOSTS } from '@bookhub/shared'
 
-const IMG_HOSTS_CSP = ALLOWED_THUMBNAIL_HOSTS.map((host) => `https://${host}`).join(' ')
+// thumbnailUrl のサーバー側スキーマ (packages/shared/src/schemas/book-schema.ts) は
+// `hostname === h || hostname.endsWith(`.${h}`)` で exact + 全サブドメインを許可する。
+// CSP img-src も同じスコープに合わせ、`https://${host}` と `https://*.${host}` の両方を出す。
+// 片方だけだとサブドメイン thumbnail がスキーマでは通るのに CSP で弾かれる不一致が起きる。
+const IMG_HOSTS_CSP = ALLOWED_THUMBNAIL_HOSTS.flatMap((host) => [
+  `https://${host}`,
+  `https://*.${host}`,
+]).join(' ')
 
 export type BuildCspOptions = {
   nonce: string

--- a/apps/web/lib/csp/generate-nonce.ts
+++ b/apps/web/lib/csp/generate-nonce.ts
@@ -1,0 +1,13 @@
+// CSP nonce はリクエスト毎に再生成し、推測不可能でなければならない。
+// 128bit (16 bytes) のランダム値を base64 エンコードして返す。
+// `crypto.getRandomValues` と `btoa` は Edge Runtime / Cloudflare Workers Runtime の
+// どちらでもサポートされており、`Buffer` のような Node.js 専用 API に依存しない。
+export function generateNonce(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}

--- a/apps/web/lib/supabase/__tests__/middleware.test.ts
+++ b/apps/web/lib/supabase/__tests__/middleware.test.ts
@@ -328,6 +328,19 @@ describe('updateSession', () => {
       expect((headers as Headers).get('x-nonce')).toBe('phase2-test-nonce')
     })
 
+    it('options.csp 指定時は NextResponse.next に Content-Security-Policy 付き request.headers を渡す', async () => {
+      const { NextResponse } = await import('next/server')
+      const request = createMockRequest('/')
+
+      await updateSession(request, { nonce: 'n', csp: "script-src 'self' 'nonce-n'" })
+
+      const calls = vi.mocked(NextResponse.next).mock.calls
+      const lastArg = calls[calls.length - 1][0] as { request: { headers: Headers } } | undefined
+      const headers = lastArg?.request.headers as Headers
+      expect(headers.get('Content-Security-Policy')).toBe("script-src 'self' 'nonce-n'")
+      expect(headers.get('x-nonce')).toBe('n')
+    })
+
     it('options 未指定時は従来どおり request をそのまま渡す (後方互換)', async () => {
       const { NextResponse } = await import('next/server')
       const request = createMockRequest('/')

--- a/apps/web/lib/supabase/__tests__/middleware.test.ts
+++ b/apps/web/lib/supabase/__tests__/middleware.test.ts
@@ -305,6 +305,57 @@ describe('updateSession', () => {
     })
   })
 
+  describe('CSP nonce オプション', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      setupMockAuth(null)
+    })
+
+    it('options.nonce 指定時は NextResponse.next に x-nonce 付き request.headers を渡す', async () => {
+      const { NextResponse } = await import('next/server')
+      const request = createMockRequest('/')
+
+      await updateSession(request, { nonce: 'phase2-test-nonce' })
+
+      const calls = vi.mocked(NextResponse.next).mock.calls
+      expect(calls.length).toBeGreaterThan(0)
+      const lastArg = calls[calls.length - 1][0] as
+        | { request: { headers: Headers } }
+        | { request: NextRequest }
+        | undefined
+      const headers = (lastArg as { request: { headers: Headers } } | undefined)?.request.headers
+      expect(headers).toBeInstanceOf(Headers)
+      expect((headers as Headers).get('x-nonce')).toBe('phase2-test-nonce')
+    })
+
+    it('options 未指定時は従来どおり request をそのまま渡す (後方互換)', async () => {
+      const { NextResponse } = await import('next/server')
+      const request = createMockRequest('/')
+
+      await updateSession(request)
+
+      const calls = vi.mocked(NextResponse.next).mock.calls
+      const lastArg = calls[calls.length - 1][0] as { request: unknown } | undefined
+      expect(lastArg?.request).toBe(request)
+    })
+
+    it('Bearer pass-through 経路でも x-nonce が伝搬される', async () => {
+      const { NextResponse } = await import('next/server')
+      const request = createMockRequest('/api/scrape')
+      request.headers = {
+        get: (name: string) =>
+          name.toLowerCase() === 'authorization' ? 'Bearer valid-token' : null,
+      } as unknown as NextRequest['headers']
+
+      await updateSession(request, { nonce: 'bearer-nonce' })
+
+      const calls = vi.mocked(NextResponse.next).mock.calls
+      const lastArg = calls[calls.length - 1][0] as { request: { headers: Headers } } | undefined
+      const headers = lastArg?.request.headers as Headers
+      expect(headers.get('x-nonce')).toBe('bearer-nonce')
+    })
+  })
+
   describe('セキュリティ', () => {
     it('getUser() が呼ばれる（getSession ではなく）', async () => {
       const { mockGetUser } = setupMockAuth(null)

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -11,10 +11,17 @@ export type UpdateSessionOptions = {
    * 呼び出し側 (middleware オーケストレータ) が response.headers に set する。
    */
   nonce?: string
+  /**
+   * CSP 文字列。指定された場合、`NextResponse.next()` 経路で request.headers にも
+   * `Content-Security-Policy` を付与し、Next.js が render 時に nonce 抽出
+   * (`getScriptNonceFromHeader`) するための公式な経路に乗せる。response.headers にも
+   * 同じ値を呼び出し側で set する想定 (Next.js 公式 docs と同等のパターン)。
+   */
+  csp?: string
 }
 
 export async function updateSession(request: NextRequest, options: UpdateSessionOptions = {}) {
-  const { nonce } = options
+  const { nonce, csp } = options
 
   // setAll コールバックは Supabase が refresh した cookie を request.cookies.set 経由で反映する。
   // Next.js の RequestCookies は内部で同じ Headers インスタンス (`_headers`) を共有しており、
@@ -22,9 +29,10 @@ export async function updateSession(request: NextRequest, options: UpdateSession
   // 更新後の Cookie が新しいスナップショットに含まれる。逆に setAll 前の古いスナップショットを
   // 使い回すと cookie refresh が失われるため、buildNextOptions は呼び出し毎に新しい snapshot を作る。
   const buildNextOptions = () => {
-    if (!nonce) return { request }
+    if (!nonce && !csp) return { request }
     const headers = new Headers(request.headers)
-    headers.set('x-nonce', nonce)
+    if (nonce) headers.set('x-nonce', nonce)
+    if (csp) headers.set('Content-Security-Policy', csp)
     return { request: { headers } }
   }
 

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -3,8 +3,30 @@ import { NextResponse, type NextRequest } from 'next/server'
 
 const PUBLIC_PATHS = ['/', '/login', '/signup']
 
-export async function updateSession(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request })
+export type UpdateSessionOptions = {
+  /**
+   * CSP nonce。指定された場合、`NextResponse.next()` 経路すべてに `x-nonce` request header
+   * を付与し、Next.js が RSC ハイドレーションスクリプトに自動で nonce を埋め込めるようにする。
+   * リダイレクト/JSON 経路ではブラウザに到達するレスポンス自体には影響せず、CSP ヘッダ自身は
+   * 呼び出し側 (middleware オーケストレータ) が response.headers に set する。
+   */
+  nonce?: string
+}
+
+export async function updateSession(request: NextRequest, options: UpdateSessionOptions = {}) {
+  const { nonce } = options
+
+  // setAll コールバックは Supabase が refresh した cookie を request.cookies へ反映する。
+  // request.cookies の変更は request.headers にも同期するため、x-nonce を載せた snapshot は
+  // setAll 呼び出しごとに作り直す必要がある (古い snapshot を使うと cookie 更新が失われる)。
+  const buildNextOptions = () => {
+    if (!nonce) return { request }
+    const headers = new Headers(request.headers)
+    headers.set('x-nonce', nonce)
+    return { request: { headers } }
+  }
+
+  let supabaseResponse = NextResponse.next(buildNextOptions())
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -16,7 +38,7 @@ export async function updateSession(request: NextRequest) {
         },
         setAll(cookiesToSet: { name: string; value: string; options: Record<string, unknown> }[]) {
           cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
-          supabaseResponse = NextResponse.next({ request })
+          supabaseResponse = NextResponse.next(buildNextOptions())
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options),
           )
@@ -37,7 +59,7 @@ export async function updateSession(request: NextRequest) {
     hasBearerToken &&
     BEARER_AUTH_PATHS.some((path) => pathname === path || pathname.startsWith(path + '/'))
   ) {
-    return NextResponse.next({ request })
+    return NextResponse.next(buildNextOptions())
   }
 
   // CRITICAL: getSession() はサーバーサイドで信頼不可。必ず getUser() を使うこと

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -16,9 +16,11 @@ export type UpdateSessionOptions = {
 export async function updateSession(request: NextRequest, options: UpdateSessionOptions = {}) {
   const { nonce } = options
 
-  // setAll コールバックは Supabase が refresh した cookie を request.cookies へ反映する。
-  // request.cookies の変更は request.headers にも同期するため、x-nonce を載せた snapshot は
-  // setAll 呼び出しごとに作り直す必要がある (古い snapshot を使うと cookie 更新が失われる)。
+  // setAll コールバックは Supabase が refresh した cookie を request.cookies.set 経由で反映する。
+  // Next.js の RequestCookies は内部で同じ Headers インスタンス (`_headers`) を共有しており、
+  // set 時に Cookie ヘッダを書き戻す実装のため、`new Headers(request.headers)` を取り直すと
+  // 更新後の Cookie が新しいスナップショットに含まれる。逆に setAll 前の古いスナップショットを
+  // 使い回すと cookie refresh が失われるため、buildNextOptions は呼び出し毎に新しい snapshot を作る。
   const buildNextOptions = () => {
     if (!nonce) return { request }
     const headers = new Headers(request.headers)

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -6,16 +6,17 @@ import { updateSession } from '@/lib/supabase/middleware'
 const isDev = process.env.NODE_ENV === 'development'
 
 export async function middleware(request: NextRequest) {
-  // CSP nonce はリクエスト毎に再生成し、request header (x-nonce) と response header (CSP) の
-  // 両方に乗せる。x-nonce は Next.js が RSC ハイドレーションスクリプトに自動付与する用、
-  // CSP はブラウザに対する制約。
+  // CSP nonce はリクエスト毎に再生成し、request header (x-nonce, Content-Security-Policy) と
+  // response header (Content-Security-Policy) の両方に乗せる。Next.js は render 時に
+  // request.headers['content-security-policy'] から nonce を抽出する (getScriptNonceFromHeader)
+  // ため request 側にも CSP が必要。response 側はブラウザに対する制約。
   const nonce = generateNonce()
   const csp = buildContentSecurityPolicy({ nonce, isDev })
 
   // 出口で 1 回だけ CSP を set する設計にすることで、updateSession 内の next/redirect/json 全
   // 経路 (Bearer pass-through 含む) に CSP が漏れなく付与される。CSP 注入と認証 Cookie 同期の
   // 責務をオーケストレータ層で分離する。
-  const response = await updateSession(request, { nonce })
+  const response = await updateSession(request, { nonce, csp })
   response.headers.set('Content-Security-Policy', csp)
   return response
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,8 +1,23 @@
 import { type NextRequest } from 'next/server'
+import { buildContentSecurityPolicy } from '@/lib/csp/build-csp'
+import { generateNonce } from '@/lib/csp/generate-nonce'
 import { updateSession } from '@/lib/supabase/middleware'
 
+const isDev = process.env.NODE_ENV === 'development'
+
 export async function middleware(request: NextRequest) {
-  return await updateSession(request)
+  // CSP nonce はリクエスト毎に再生成し、request header (x-nonce) と response header (CSP) の
+  // 両方に乗せる。x-nonce は Next.js が RSC ハイドレーションスクリプトに自動付与する用、
+  // CSP はブラウザに対する制約。
+  const nonce = generateNonce()
+  const csp = buildContentSecurityPolicy({ nonce, isDev })
+
+  // 出口で 1 回だけ CSP を set する設計にすることで、updateSession 内の next/redirect/json 全
+  // 経路 (Bearer pass-through 含む) に CSP が漏れなく付与される。CSP 注入と認証 Cookie 同期の
+  // 責務をオーケストレータ層で分離する。
+  const response = await updateSession(request, { nonce })
+  response.headers.set('Content-Security-Policy', csp)
+  return response
 }
 
 export const config = {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,38 +1,9 @@
 import type { NextConfig } from 'next'
-import { ALLOWED_THUMBNAIL_HOSTS } from '@bookhub/shared'
 
-// 書影として許可する画像ホスト一覧は @bookhub/shared から import して
-// サーバー側スキーマ (POST 時の validate) と CSP img-src を単一ソースで同期する。
-const IMG_HOSTS_CSP = ALLOWED_THUMBNAIL_HOSTS.map((host) => `https://${host}`).join(' ')
-
-// 本番 CSP: script-src は `'self' 'unsafe-inline'` のまま残存している。
-// `unsafe-inline` は Next.js App Router の RSC ハイドレーション用インラインスクリプト
-// のため現時点で必須。これを nonce 方式 (middleware で per-request nonce を style/script
-// に差し込む) へ移行するリファクタリングは #28 で実施予定。未完了のため現状では XSS が
-// 成立した場合のスクリプト注入耐性が限定的である点に注意。
-//
-// dev モードでは Next.js の React Refresh runtime が eval() を使うため
-// 'unsafe-eval' が必要。本番には含めない。これがないと HMR runtime 初期化で
-// CSP エラーが発生し、クライアント React ツリーがハイドレートされず、すべての
-// useEffect / client component がサイレントに動作不能になる。
-const isDev = process.env.NODE_ENV === 'development'
-const SCRIPT_SRC = isDev
-  ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-  : "script-src 'self' 'unsafe-inline'"
-const CSP_VALUE = [
-  "default-src 'self'",
-  `img-src 'self' data: ${IMG_HOSTS_CSP}`,
-  SCRIPT_SRC,
-  "style-src 'self' 'unsafe-inline'",
-  "font-src 'self' data:",
-  "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "object-src 'none'",
-  "worker-src 'none'",
-].join('; ')
-
+// Content-Security-Policy は middleware (apps/web/middleware.ts) で per-request nonce を埋め込んだ
+// 動的な値を response header に set する。ここに静的 CSP を残すと middleware の値と二重定義になり、
+// 後から評価される側の値で上書きされる挙動が version 依存で不安定になるため、CSP は middleware
+// に一元化する。img-src の許可ホスト一覧などもすべて apps/web/lib/csp/build-csp.ts に集約。
 const nextConfig: NextConfig = {
   async headers() {
     return [
@@ -42,7 +13,6 @@ const nextConfig: NextConfig = {
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-          { key: 'Content-Security-Policy', value: CSP_VALUE },
         ],
       },
     ]

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -31,7 +31,11 @@ export default defineConfig({
         test: {
           name: 'node',
           environment: 'node',
-          include: ['app/**/__tests__/**/*.test.ts', 'lib/**/__tests__/**/*.test.ts'],
+          include: [
+            'app/**/__tests__/**/*.test.ts',
+            'lib/**/__tests__/**/*.test.ts',
+            '__tests__/**/*.test.ts',
+          ],
         },
       },
     ],

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -516,7 +516,7 @@ Authorization: Bearer <token>
 `apps/web` は middleware で per-request nonce を生成し、`script-src 'self' 'nonce-{nonce}' 'strict-dynamic'` で運用している (詳細は `docs/specs/architecture.md` §6.5)。inline script を追加する際は以下のルールに従う。
 
 - **inline `<script>` は必ず nonce を付与する**: Server Component なら `import { headers } from 'next/headers'` で `(await headers()).get('x-nonce')` を取得し、`<Script nonce={nonce}>` (next/script) または `<script nonce={nonce}>` で渡す
-- **サードパーティ script は `next/script` 経由で読み込む**: `<script src="https://...">` 直書きは `'strict-dynamic'` 配下では nonce 未付与で動かない。Sentry / GA / 楽天 widget 等を追加する場合は必ず `next/script` を使うこと
+- **サードパーティ script は `next/script` 経由 or 明示的に nonce を付与する**: `<script src="https://...">` 直書きは `'strict-dynamic'` 配下では nonce 未付与だと弾かれる。`next/script` を使えば自動付与されるため推奨。直接 `<script>` タグを使う必要がある場合は `<script src="..." nonce={nonce}>` のように `headers()` から取得した nonce を明示的に渡すこと
 - **inline `style="..."` 属性は引き続き許可**: `style-src 'self' 'unsafe-inline'` を据え置いているため、Tailwind の static class や Radix Popper の動的 inline style はそのまま動く
 - **CSP に新しい許可ホスト (img-src / connect-src / font-src 等) を追加する場合**: `apps/web/lib/csp/build-csp.ts` を編集する。`next.config.ts` に CSP は無いので注意
 

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -511,6 +511,15 @@ Authorization: Bearer <token>
 - husky の pre-commit フックにより、コミット時に `pnpm lint` と `pnpm format:check` が自動実行される
 - コミット前に `pnpm fix` を実行して問題を解消しておくことを推奨
 
+## CSP nonce ガイド (Web)
+
+`apps/web` は middleware で per-request nonce を生成し、`script-src 'self' 'nonce-{nonce}' 'strict-dynamic'` で運用している (詳細は `docs/specs/architecture.md` §6.5)。inline script を追加する際は以下のルールに従う。
+
+- **inline `<script>` は必ず nonce を付与する**: Server Component なら `import { headers } from 'next/headers'` で `(await headers()).get('x-nonce')` を取得し、`<Script nonce={nonce}>` (next/script) または `<script nonce={nonce}>` で渡す
+- **サードパーティ script は `next/script` 経由で読み込む**: `<script src="https://...">` 直書きは `'strict-dynamic'` 配下では nonce 未付与で動かない。Sentry / GA / 楽天 widget 等を追加する場合は必ず `next/script` を使うこと
+- **inline `style="..."` 属性は引き続き許可**: `style-src 'self' 'unsafe-inline'` を据え置いているため、Tailwind の static class や Radix Popper の動的 inline style はそのまま動く
+- **CSP に新しい許可ホスト (img-src / connect-src / font-src 等) を追加する場合**: `apps/web/lib/csp/build-csp.ts` を編集する。`next.config.ts` に CSP は無いので注意
+
 ## Extension 開発ガイド
 
 ### Content Script の実装パターン

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -519,6 +519,63 @@ const backHref = q ? `/bookshelf?q=${encodeURIComponent(q)}` : '/bookshelf'
 - `apps/extension/src/utils/constants.ts` — `TRIGGER_TTL_MS`, `STORE_REGISTRY`, `ScrapeTriggerSource`
 - `packages/shared/src/schemas/external-message-schema.ts` — `TriggerScrapeMessage` 型定義
 
+### 6.5 CSP nonce + strict-dynamic 戦略 (ADR)
+
+**決定:** `script-src` は `'self' 'nonce-{nonce}' 'strict-dynamic'` (dev のみ `'unsafe-eval'` を追加)。CSP は middleware で per-request nonce を埋め込み、`response.headers` に set する。`style-src` は `'self' 'unsafe-inline'` を当面据え置く。
+
+**背景:**
+
+- Issue #12 (本棚ギャラリー UI) の code review で、`script-src` の `'unsafe-inline'` により XSS 防御の CSP 実効性が大幅に下がる点を指摘された
+- 同 PR では `wss` / `object-src` / `worker-src` 等の他 CSP 強化を先行投入し、nonce 方式への移行は Issue #28 として分離した
+- Next.js 16 公式ドキュメントが推奨する middleware ベースの nonce 注入パターンに準拠
+
+**採用した設計:**
+
+- **middleware オーケストレータ (`apps/web/middleware.ts`)**: per-request で nonce 生成 → `updateSession` 呼び出し (CSP 注入と認証 Cookie 同期の責務分離) → 出口で `response.headers.set('Content-Security-Policy', csp)` を 1 回だけ実行
+- **CSP ビルダー (`apps/web/lib/csp/build-csp.ts`)**: 純粋関数として CSP 文字列を組み立て、許可ホスト一覧を `@bookhub/shared` から単一ソースで取得
+- **nonce 生成 (`apps/web/lib/csp/generate-nonce.ts`)**: `crypto.getRandomValues(Uint8Array(16))` + `btoa` で 128bit base64 nonce を生成。`Buffer` 非依存のため Edge Runtime / Cloudflare Workers Runtime で動作
+- **layout (`apps/web/app/layout.tsx`)**: `await headers()` で `x-nonce` を取得し、next-themes の inline 初期化スクリプト用に `nonce` prop で渡す。Next.js が出力する RSC ハイドレーションスクリプトには `x-nonce` request header から自動付与されるため追加対応不要
+
+**実機検証 (`pnpm build && pnpm start`):**
+
+- `script-src` から `'unsafe-inline'` が外れ、`'self' 'nonce-{nonce}' 'strict-dynamic'` に置換されることを確認
+- 連続リクエストで nonce が変化することを確認
+- Next.js 出力の `<script src="...">` および inline `<script>` (next-themes 初期化、`__next_f` ストリーミング含む) すべてに同一 nonce が自動付与されることを確認
+
+**style-src の判断:**
+
+- 現在の rendered HTML には inline `<style>` も `style=""` 属性も含まれないが、将来 Radix Popper / shadcn-ui Dialog 等が動的 inline style を出す可能性があるため、`'unsafe-inline'` を据え置き
+- 主たる脅威 (script injection) は nonce + strict-dynamic で完全防御済み。style injection 経由の攻撃 (例: `background-image` で password field 値を抽出) は input サニタイズ等の他層で軽減
+- 将来 inline style 利用が無いと確証できた時点で `style-src 'self' 'nonce-{nonce}'` への厳格化を別 Issue として検討
+
+**副作用 (architect レビューで予測済み):**
+
+- `await headers()` を RootLayout に追加したことで、サイト全体が **Dynamic Rendering 強制**化される (LP / login / signup を含む)
+- per-request nonce は HTML キャッシュと原理的に両立しないため、Cloudflare CDN の HTML キャッシュは元から使えず、これは許容範囲
+- `_next/static/*` のアセットキャッシュには影響なし
+
+**却下した代替案:**
+
+- **`next.config.ts` に nonce 抜きの fallback CSP を残置 (defense-in-depth)**: nonce 抜きの CSP は `strict-dynamic` を含めると Next.js が動かないため、結局 `'unsafe-inline'` 含みになり実質効果なし。「動いているように見えて緩い」状態を発見しにくくする逆効果のため不採用
+- **`crypto.randomUUID()` で nonce を作る**: UUID 文字列はハイフンを含み、CSP nonce 仕様 (`base64-value` 規定) と曖昧で一部ブラウザ・パーサーで弾かれる懸念。`crypto.getRandomValues` + base64 を採用
+- **hash ベース CSP (`'sha256-...'`)**: Next.js のチャンク内容はビルド毎に変動し、next-themes の inline script もテーマ設定で変動するため運用負荷が高い
+
+**運用注意点:**
+
+- **新規 inline `<script>` を追加する場合**: `headers()` から nonce を取得して `<Script nonce={nonce}>` (next/script) または DOM 直書きの `<script nonce={nonce}>` で渡す。`<script src="...">` 直書きは `strict-dynamic` 配下では nonce 無しで動かない
+- **サードパーティ script (Sentry / GA / 楽天 widget 等)**: 必ず `next/script` 経由で読み込む。`strict-dynamic` は nonce 付き script が動的挿入した script を暗黙的に許可するため、bootstrap script に nonce が付けば子 script は自動的に動作
+- **CSP 違反デバッグ**: 本番デプロイ後の違反検知のため、将来的に `report-to` / `report-uri` での違反レポート収集を別 Issue で検討
+- **middleware 経路の保守**: `lib/supabase/middleware.ts` で新たな `NextResponse.next/redirect/json` 経路を追加する場合、CSP は middleware 出口で一元的に set されるため経路追加側で意識する必要は無い。ただし `updateSession` 内で response を完結する経路を増やす場合は引き続き orchestrator 出口で set される構造を壊さないこと
+
+**関連ファイル:**
+
+- `apps/web/middleware.ts` — CSP nonce オーケストレータ
+- `apps/web/lib/csp/build-csp.ts` — CSP ビルダー (純粋関数)
+- `apps/web/lib/csp/generate-nonce.ts` — Edge Runtime 互換 nonce 生成
+- `apps/web/lib/supabase/middleware.ts` — `updateSession(request, { nonce })` で `x-nonce` を request header に伝搬
+- `apps/web/app/layout.tsx` — `await headers()` で nonce を取得し ThemeProvider へ配布
+- `apps/web/next.config.ts` — CSP 静的定義は撤去 (middleware に一元化)、X-Frame-Options 等の他セキュリティヘッダは残置
+
 ---
 
 ## 7. Cloudflare Pages Edge Runtime の制約

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -527,11 +527,11 @@ const backHref = q ? `/bookshelf?q=${encodeURIComponent(q)}` : '/bookshelf'
 
 - Issue #12 (本棚ギャラリー UI) の code review で、`script-src` の `'unsafe-inline'` により XSS 防御の CSP 実効性が大幅に下がる点を指摘された
 - 同 PR では `wss` / `object-src` / `worker-src` 等の他 CSP 強化を先行投入し、nonce 方式への移行は Issue #28 として分離した
-- Next.js 16 公式ドキュメントが推奨する middleware ベースの nonce 注入パターンに準拠
+- Next.js 15+ 公式ドキュメント (App Router CSP guide) が推奨する middleware ベースの nonce 注入パターンに準拠
 
 **採用した設計:**
 
-- **middleware オーケストレータ (`apps/web/middleware.ts`)**: per-request で nonce 生成 → `updateSession` 呼び出し (CSP 注入と認証 Cookie 同期の責務分離) → 出口で `response.headers.set('Content-Security-Policy', csp)` を 1 回だけ実行
+- **middleware オーケストレータ (`apps/web/middleware.ts`)**: per-request で nonce 生成 → `updateSession` 呼び出し (CSP 注入と認証 Cookie 同期の責務分離) → 出口で `response.headers.set('Content-Security-Policy', csp)` を 1 回だけ実行。redirect (3xx) や JSON 401 のようなブラウザが CSP を評価しないレスポンスにも一律で付与されるが、これは経路漏れ防止の保険であり害は無い (HTML レスポンスのみがブラウザで CSP 評価される)
 - **CSP ビルダー (`apps/web/lib/csp/build-csp.ts`)**: 純粋関数として CSP 文字列を組み立て、許可ホスト一覧を `@bookhub/shared` から単一ソースで取得
 - **nonce 生成 (`apps/web/lib/csp/generate-nonce.ts`)**: `crypto.getRandomValues(Uint8Array(16))` + `btoa` で 128bit base64 nonce を生成。`Buffer` 非依存のため Edge Runtime / Cloudflare Workers Runtime で動作
 - **layout (`apps/web/app/layout.tsx`)**: `await headers()` で `x-nonce` を取得し、next-themes の inline 初期化スクリプト用に `nonce` prop で渡す。Next.js が出力する RSC ハイドレーションスクリプトには `x-nonce` request header から自動付与されるため追加対応不要


### PR DESCRIPTION
## Summary

Issue #28 対応。`apps/web/next.config.ts` に直書きされていた CSP の `script-src 'unsafe-inline'` を、middleware で per-request nonce を生成する方式 (`'self' 'nonce-{nonce}' 'strict-dynamic'`) に置き換える。

- middleware オーケストレータ層で出口一元集約: `updateSession` には CSP ロジックを入れず、`apps/web/middleware.ts` が出口で 1 回だけ `response.headers.set('Content-Security-Policy', csp)` を実行 (next/redirect/json/Bearer pass-through 全経路をカバー)
- nonce 生成は Edge Runtime / Cloudflare Workers 互換の `crypto.getRandomValues(Uint8Array(16))` + `btoa` (Buffer 非依存)
- `app/layout.tsx` を async 化し `await headers()` で `x-nonce` を取得、next-themes に `nonce` prop で渡す。Next.js が出力する RSC ハイドレーションスクリプトには `x-nonce` request header から自動付与
- `next.config.ts` の static CSP は撤去 (middleware に一元化)、X-Frame-Options 等の他セキュリティヘッダは残置
- style-src は `'unsafe-inline'` を据え置き (Tailwind v4 / shadcn-ui の inline style 互換性のため、ADR docs/specs/architecture.md §6.5 に判断根拠を記録)

## Phase 構成 (5 コミット)

| Phase | コミット | 内容 |
|-------|----------|------|
| 1 | d80268e | CSP ビルダーと nonce 生成を共通モジュール化 |
| 2 | 0ff05d4 | middleware オーケストレータ層で CSP 出口一元集約 |
| 3 | 4e17e34 | layout で nonce 配布 + next.config.ts CSP 撤去 |
| 4 | 41d3b92 | ADR (architecture.md §6.5) と CONTRIBUTING ガイド追記 |
| 5 | e406a20 | code-review 指摘事項を反映 |

## Test plan

- [x] `pnpm test` 全 314 tests パス (新規 21 tests: build-csp 8、generate-nonce 4、updateSession nonce option 3、middleware orchestrator 6)
- [x] `pnpm lint` パス
- [x] `pnpm format:check` パス
- [x] `pnpm build` (本番ビルド) 成功
- [x] `pnpm start` 実機検証: `script-src 'self' 'nonce-XXX==' 'strict-dynamic'` で `'unsafe-inline'` 消滅、nonce が毎リクエスト変化、Next.js が全 script タグ (chunks + inline + next-themes 初期化) に同一 nonce を自動付与することを curl で確認
- [ ] Cloudflare Pages preview (`opennextjs-cloudflare dev`) で Workers Runtime 動作確認 (別 Issue で検討)
- [ ] `Content-Security-Policy-Report-Only` での段階投入 (別 Issue で検討)

## 副作用 (architect レビュー予測通り)

- `await headers()` を RootLayout に追加したことで全 route が **Dynamic Rendering 強制**化される (LP / login / signup を含む)
- per-request nonce は HTML キャッシュと原理的に両立しないため、Cloudflare CDN の HTML キャッシュは元から使えず許容範囲。`_next/static/*` のアセットキャッシュには影響なし

## ドキュメント

- `docs/specs/architecture.md` §6.5 に CSP nonce + strict-dynamic 戦略の ADR を追加 (背景 / 採用設計 / 実機検証結果 / style-src 判断 / 副作用 / 却下案 / 運用注意)
- `docs/guides/CONTRIBUTING.md` に inline script 追加時の nonce 配布ガイドを追記

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リクエスト毎のCSPノンス生成とそれを使った動的なContent-Security-Policyの算出・適用を導入しました。ルートレイアウトがリクエストノンスを受け取り初期化スクリプトに渡します。

* **ドキュメント**
  * CSPノンス運用とインライン/外部スクリプトの記述ガイドを追加しました。

* **テスト**
  * ノンス生成、CSP組立、ミドルウェア経由でのノンス伝播を検証する包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->