### PR TITLE
fix(ci): production CD で pnpm run deploy を明示

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,10 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       - name: Deploy
-        run: pnpm --filter web deploy
+        # `pnpm --filter web deploy` は pnpm 10 の組み込み `pnpm deploy` (monorepo deploy)
+        # と衝突して `ERR_PNPM_INVALID_DEPLOY_TARGET` で失敗する。`run` を明示挟むと
+        # package.json の scripts.deploy が確実に解決される。
+        run: pnpm --filter web run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

PR #44 マージ後に本番 CD が pnpm 10 組み込みコマンドとの衝突で失敗した問題を修正。

## エラー内容

Workflow run [25251231332](https://github.com/Shrimprin/bookshub/actions/runs/25251231332) の Deploy ステップで:

\`\`\`
ERR_PNPM_INVALID_DEPLOY_TARGET  This command requires one parameter
\`\`\`

## 原因

pnpm 10 には \`pnpm deploy <target-dir>\` という monorepo deploy 用の組み込みコマンドが存在する。\`pnpm --filter web deploy\` の形で呼ぶと、apps/web の package.json の \`scripts.deploy\` (\`opennextjs-cloudflare deploy\`) ではなく **組み込み deploy** が解決されてしまい、引数が無いため失敗する。

preview workflow (\`cd-preview.yml\`) は \`pnpm --filter web exec -- opennextjs-cloudflare deploy --name "..."\` を使っているためこの問題を踏まなかった。

## 修正

\`pnpm --filter web run deploy\` のように \`run\` を明示挟むと、必ず package.json の scripts が優先される。

## Test plan

- [ ] PR マージ後、main で CD ワークフローが本番デプロイ成功
- [ ] production environment URL \`https://bookhub-web.ryuheykai.workers.dev\` でアクセス可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Cloudflare Workers へのデプロイメント処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->